### PR TITLE
hardcode sqljs cdn

### DIFF
--- a/lib/components/defog-components/DefogAnalysisAgentStandalone.jsx
+++ b/lib/components/defog-components/DefogAnalysisAgentStandalone.jsx
@@ -176,7 +176,7 @@ export function DefogAnalysisAgentStandalone({
                         isTemp={isTemp}
                         showToggle={showToggle}
                         metadata={metadata}
-                        defaultSidebarOpen={() =>
+                        defaultSidebarOpen={
                           defaultSidebarOpen ||
                           (window.innerWidth < 768 ? false : true)
                         }

--- a/lib/components/utils/sqlite.js
+++ b/lib/components/utils/sqlite.js
@@ -64,7 +64,8 @@ const getConn = (SQL) => {
  */
 export const initializeSQLite = async () => {
   const SQL = await initSqlJs({
-    locateFile: (file) => `https://sql.js.org/dist/${file}`,
+    locateFile: (file) =>
+      `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.10.3/sql-wasm.wasm`,
   });
   return new SQL.Database();
 };
@@ -75,7 +76,7 @@ export const initializeSQLite = async () => {
  * @param {import("sql.js").Database} config.conn - SQLite3 database instance/connection.
  * @param {string} config.query - Query to run.
  * @param {Array<any>} [config.bind] - Bind parameters.
- * @returns {Object} - Column names and results.
+ * @returns {[Array<string>, Array<Array<any>>]} [columns, rows] Column names and array of rows.
  */
 export const runQueryOnDb = ({ conn, query, bind = null }) => {
   const stmt = conn.prepare(query);


### PR DESCRIPTION
We were getting an error with the "default" sqljs cdn of `https://sql.js.org/dist/${file}`. Seems like the latest release broke it.

Using the hardcoded cdn of the 1.10.3 version from [here](https://cdnjs.com/libraries/sql.js/1.10.3).

Here's the test results. This is on the website. pushing to get that working first. I will add error handling for this in a later refactor PR.

Manufacturing:
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/5409e655-f712-40f3-b21f-6242c6c987ef">

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/6f697c47-b048-4a32-a5c0-11aec5536264">

Sales:
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/b635cb75-4d47-44e6-9801-0d0a1594ca6b">

CSV:

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/80027627-8455-463d-830d-7d01df6a72b0">
