### PR TITLE
Non sql only test for 2 step analysis (caveat: uses send email tool)

### DIFF
--- a/playwright-tests/embed-test.spec.ts
+++ b/playwright-tests/embed-test.spec.ts
@@ -100,16 +100,19 @@ test("can ask one sql-only question", async ({ page }) => {
     response.url().includes("/generate_step")
   );
 
-  // wait 3 seconds for the clarifier button to appear, then move on
-  await page.waitForTimeout(3000);
+  // we will either get a clarifier that says "Click here or press enter to"
+  // or we will bypass the clarifier, and have a thing that says "fetching data"
+  const fetchingDataLocator = page.getByText("Fetching data");
 
   // click the clarify submit button
-  const buttonClarify = page.getByRole("button", {
+  const buttonClarifyLocator = page.getByRole("button", {
     name: "Click here or press enter to",
   });
 
-  if ((await buttonClarify.count()) > 0) {
-    await buttonClarify.click();
+  await expect(fetchingDataLocator.or(buttonClarifyLocator)).toBeVisible();
+
+  if ((await buttonClarifyLocator.count()) > 0) {
+    await buttonClarifyLocator.click();
   }
 
   // now wait for the response
@@ -148,9 +151,8 @@ test("can ask one advanced question with send email usage", async ({
     "show me 5 rows and send an email to manas@defog.ai"
   );
 
-  // we will either get a clarifier that says "Clikc here or press enter to"
+  // we will either get a clarifier that says "Click here or press enter to"
   // or we will bypass the clarifier, and have a thing that says "fetching data"
-
   const fetchingDataLocator = page.getByText("Fetching data");
 
   // click the clarify submit button


### PR DESCRIPTION
**Checklist:**
- **Breaking changes:** None
- **Regression:** None


Notes:
- Now using [locator.or](https://playwright.dev/docs/api/class-locator#locator-or) for an OR type check inside `expect` for the "clarify button appears or not" check. We move on if either we get a clarify button or a "Fetching data" message (which appears if we go straight to planning without clarifying).
- To test the non sql-only method: I am asking the model to also send an email. This gives me some surity that we _will_ get two steps. Lmk if there's a way to test this in a more tool agnostic manner?
- Also added checks for the network _request_ (not just the response) to ensure the toggle was changed correctly.

To run tests:
`npx playwright test --ui`