### PR TITLE
Convert <Table/> component to typescript, add ability to manually go to a specific page

### DIFF
--- a/lib/components/core-ui/Table.tsx
+++ b/lib/components/core-ui/Table.tsx
@@ -376,6 +376,24 @@ export function Table({
                 );
               }}
             />
+            {maxPage > 1 && (
+              <div className="flex items-center ml-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={maxPage}
+                  value={currentPage}
+                  onChange={(e) => {
+                    const value = parseInt(e.target.value);
+                    if (!isNaN(value) && value >= 1 && value <= maxPage) {
+                      setCurrentPage(value);
+                    }
+                  }}
+                  className="w-16 px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"
+                  placeholder="Page"
+                />
+              </div>
+            )}
           </div>
           {(pagination.showSizeChanger === undefined
             ? true


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Details

Added typescript interfaces to the `<Table>` component, and also added an option to manually go to a given page inside the table (if there is more than 1 page). Quick video here! https://www.loom.com/share/789bd73a192e4c11acc40d1917bf1cf5

--

<details open>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `npm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `npm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
