### PR TITLE
Add a search bar for tables, add keyboard shortcuts to tables

### DIFF
--- a/lib/components/core-ui/Table.tsx
+++ b/lib/components/core-ui/Table.tsx
@@ -3,7 +3,6 @@ import React, {
   useEffect,
   useMemo,
   useState,
-  Suspense,
   useTransition,
   useRef,
   useCallback,
@@ -281,14 +280,12 @@ export function Table({
     [columnsToDisplay]
   );
 
-  const dataIndexToColumnMap = useMemo(() => 
-    columnsToDisplay.reduce<Record<string, Column>>(
-      (acc, column) => {
+  const dataIndexToColumnMap = useMemo(
+    () =>
+      columnsToDisplay.reduce<Record<string, Column>>((acc, column) => {
         acc[column.dataIndex] = column;
         return acc;
-      },
-      {}
-    ),
+      }, {}),
     [columnsToDisplay]
   );
 
@@ -308,7 +305,9 @@ export function Table({
       return dataIndexes.some((dataIndex) => {
         const cellValue = row[dataIndex];
         if (cellValue == null) return false;
-        return String(cellValue).toLowerCase().includes(searchQuery.toLowerCase());
+        return String(cellValue)
+          .toLowerCase()
+          .includes(searchQuery.toLowerCase());
       });
     });
   }, [rowsWithIndex, searchQuery, dataIndexes]);
@@ -331,8 +330,8 @@ export function Table({
     });
   }, [filteredRows, sortColumn, sortOrder, columnsToDisplay]);
 
-  const maxPage = useMemo(() => 
-    Math.ceil(sortedRows.length / pageSize),
+  const maxPage = useMemo(
+    () => Math.ceil(sortedRows.length / pageSize),
     [sortedRows.length, pageSize]
   );
 
@@ -391,31 +390,40 @@ export function Table({
     setSortOrder(newOrder);
   }
 
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.target instanceof HTMLInputElement || (e.target as HTMLElement).isContentEditable) {
-      if (e.key === 'Escape' && document.activeElement === searchInputRef.current) {
-        searchInputRef.current?.blur();
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        (e.target as HTMLElement).isContentEditable
+      ) {
+        if (
+          e.key === "Escape" &&
+          document.activeElement === searchInputRef.current
+        ) {
+          searchInputRef.current?.blur();
+        }
+        return;
       }
-      return;
-    }
 
-    switch (e.key) {
-      case 'ArrowLeft':
-        tryPageChange(currentPage - 1 < 1 ? 1 : currentPage - 1);
-        break;
-      case 'ArrowRight':
-        tryPageChange(currentPage + 1 > maxPage ? maxPage : currentPage + 1);
-        break;
-      case 's':
-        e.preventDefault();
-        searchInputRef.current?.focus();
-        break;
-    }
-  }, [currentPage, maxPage, tryPageChange]);
+      switch (e.key) {
+        case "ArrowLeft":
+          tryPageChange(currentPage - 1 < 1 ? 1 : currentPage - 1);
+          break;
+        case "ArrowRight":
+          tryPageChange(currentPage + 1 > maxPage ? maxPage : currentPage + 1);
+          break;
+        case "s":
+          e.preventDefault();
+          searchInputRef.current?.focus();
+          break;
+      }
+    },
+    [currentPage, maxPage, tryPageChange]
+  );
 
   useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
   const pager = useMemo(() => {


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** No
- **Regression:** No

--

## Improve Tables!

Tables are often very long. After we ask an initial question (like, say, which referral sources led to the most users) - we might then want to filter the long table to just a few values. This PR accomplishes that, and also adds keyboard shortcuts to tablrs.

### Search Bar for tables

We now have a search bar for tables, like below

![image](https://github.com/user-attachments/assets/ad5ee054-1832-4437-b99a-e9ef1a63d343)

When we search for something, we automatically get values that match what we have searched for.
![image](https://github.com/user-attachments/assets/22750061-4c97-4080-8e01-0aef54cdec86)

### Keyboard shortcuts for tables

- `s` for focusing on the table search bar
- left and right arrow keys for moving the table pagination

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
