### PR TITLE
[Refactor] Use centralized keymap for all keyboard shortcuts

### DIFF
--- a/lib/components/agent/analysis-tree-viewer/DraggableInput.tsx
+++ b/lib/components/agent/analysis-tree-viewer/DraggableInput.tsx
@@ -3,6 +3,7 @@ import { Move, ArrowRight, SquarePen } from "lucide-react";
 import { TextArea } from "@ui-components";
 import { twMerge } from "tailwind-merge";
 import { KeyboardShortcutIndicator } from "../../core-ui/KeyboardShortcutIndicator";
+import { KEYMAP, matchesKey } from "../../../constants/keymap";
 
 interface DraggableInputProps {
   searchBarClasses?: string;
@@ -119,13 +120,13 @@ let DraggableInput = forwardRef(function DraggableInput(
     function handleKeyPress(e: KeyboardEvent) {
       // Only handle keys if no other element is focused
       if (document.activeElement === document.body) {
-        if (e.key === "/") {
+        if (matchesKey(e.key, KEYMAP.FOCUS_SEARCH)) {
           e.preventDefault();
           // Focus the textarea
           if (ref && "current" in ref && ref.current) {
             ref.current.focus();
           }
-        } else if (e.key === "n" || e.key === "N") {
+        } else if (matchesKey(e.key, KEYMAP.NEW_CONVERSATION)) {
           e.preventDefault();
           onNewConversationTextClick();
           if (ref && "current" in ref && ref.current) {
@@ -208,7 +209,7 @@ let DraggableInput = forwardRef(function DraggableInput(
                 }
               />
               <KeyboardShortcutIndicator
-                shortcut="/"
+                shortcut={KEYMAP.FOCUS_SEARCH}
                 className="absolute -translate-y-1/2 opacity-50 pointer-events-none right-3 top-1/2"
               />
               <span
@@ -220,7 +221,7 @@ let DraggableInput = forwardRef(function DraggableInput(
                 <div className="flex items-center gap-2">
                   <SquarePen />
                   <KeyboardShortcutIndicator
-                    shortcut="n"
+                    shortcut={KEYMAP.NEW_CONVERSATION}
                     className="opacity-50"
                   />
                 </div>

--- a/lib/components/agent/analysis/step-results/StepResultsTable.tsx
+++ b/lib/components/agent/analysis/step-results/StepResultsTable.tsx
@@ -31,6 +31,7 @@ import StepResultAnalysis from "./StepResultAnalysis";
 import type { ParsedOutput, Step } from "../analysisManager";
 import type { AnalysisTreeManager } from "../../analysis-tree-viewer/analysisTreeManager";
 import { KeyboardShortcutIndicator } from "../../../core-ui/KeyboardShortcutIndicator";
+import { KEYMAP, matchesKey } from "../../../../constants/keymap";
 
 interface TabItem {
   key: string;
@@ -311,12 +312,12 @@ export function StepResultsTable({
     const handleKeyPress = (e: KeyboardEvent) => {
       // Only handle keypress if no element is focused
       if (document.activeElement === document.body) {
-        if (e.key === "c" || e.key === "C") {
+        if (matchesKey(e.key, KEYMAP.VIEW_CHART)) {
           const chartTab = results.find((tab) => tab.key === "chart");
           if (chartTab) {
             analysisTreeManager.setActiveTab(analysisId, "chart");
           }
-        } else if (e.key === "t" || e.key === "T") {
+        } else if (matchesKey(e.key, KEYMAP.VIEW_TABLE)) {
           const tableTab = results.find((tab) => tab.key === "table");
           if (tableTab) {
             analysisTreeManager.setActiveTab(analysisId, "table");
@@ -356,13 +357,13 @@ export function StepResultsTable({
                   </span>
                   {tab.key === "table" && (
                     <KeyboardShortcutIndicator
-                      shortcut="t"
+                      shortcut={KEYMAP.VIEW_TABLE}
                       className="opacity-50 px-1 py-0.5"
                     />
                   )}
                   {tab.key === "chart" && (
                     <KeyboardShortcutIndicator
-                      shortcut="c"
+                      shortcut={KEYMAP.VIEW_CHART}
                       className="opacity-50 px-1 py-0.5"
                     />
                   )}

--- a/lib/components/core-ui/Table.tsx
+++ b/lib/components/core-ui/Table.tsx
@@ -11,6 +11,8 @@ import { twMerge } from "tailwind-merge";
 import { SingleSelect } from "./SingleSelect";
 import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { MessageManagerContext } from "./Message";
+import { KeyboardShortcutIndicator } from "./KeyboardShortcutIndicator";
+import { KEYMAP, matchesKey } from "../../constants/keymap";
 
 const allowedPageSizes = [5, 10, 20, 50, 100];
 
@@ -397,7 +399,7 @@ export function Table({
         (e.target as HTMLElement).isContentEditable
       ) {
         if (
-          e.key === "Escape" &&
+          matchesKey(e.key, KEYMAP.TABLE_BLUR_SEARCH) &&
           document.activeElement === searchInputRef.current
         ) {
           searchInputRef.current?.blur();
@@ -406,13 +408,13 @@ export function Table({
       }
 
       switch (e.key) {
-        case "ArrowLeft":
+        case KEYMAP.TABLE_PREV_PAGE:
           tryPageChange(currentPage - 1 < 1 ? 1 : currentPage - 1);
           break;
-        case "ArrowRight":
+        case KEYMAP.TABLE_NEXT_PAGE:
           tryPageChange(currentPage + 1 > maxPage ? maxPage : currentPage + 1);
           break;
-        case "s":
+        case KEYMAP.TABLE_FOCUS_SEARCH:
           e.preventDefault();
           searchInputRef.current?.focus();
           break;
@@ -536,15 +538,25 @@ export function Table({
   return (
     <div className={twMerge("px-4 sm:px-6 lg:px-8", rootClassNames)}>
       {showSearch && (
-        <div className="mb-4">
+        <div className="relative mb-4">
           <input
             ref={searchInputRef}
             type="text"
+            className="w-full px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"
+            placeholder="Search..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search table... (Press 's' to focus)"
-            className="block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 dark:text-gray-100 dark:bg-gray-800 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+            onChange={(e) => {
+              startTransition(() => {
+                setSearchQuery(e.target.value);
+              });
+            }}
           />
+          <div className="absolute right-3 top-1/2 -translate-y-1/2">
+            <KeyboardShortcutIndicator
+              shortcut={KEYMAP.TABLE_FOCUS_SEARCH}
+              className="opacity-50"
+            />
+          </div>
         </div>
       )}
       {paginationPosition === "top" && pager}

--- a/lib/constants/keymap.ts
+++ b/lib/constants/keymap.ts
@@ -1,0 +1,23 @@
+export const KEYMAP = {
+  // DraggableInput shortcuts
+  FOCUS_SEARCH: '/',         // Focus the search textarea
+  NEW_CONVERSATION: 'n',     // Start a new conversation
+
+  // StepResultsTable shortcuts
+  VIEW_CHART: 'c',          // Switch to chart view
+  VIEW_TABLE: 't',          // Switch to table view
+
+  // Table shortcuts
+  TABLE_PREV_PAGE: 'ArrowLeft',     // Go to previous page in table
+  TABLE_NEXT_PAGE: 'ArrowRight',    // Go to next page in table
+  TABLE_FOCUS_SEARCH: 's',          // Focus the table search input
+  TABLE_BLUR_SEARCH: 'Escape',      // Blur/unfocus the table search input
+} as const;
+
+// Type for all possible keymap values
+export type KeymapKey = typeof KEYMAP[keyof typeof KEYMAP];
+
+// Helper function to check if a key matches (case insensitive)
+export const matchesKey = (pressedKey: string, targetKey: KeymapKey): boolean => {
+  return pressedKey.toLowerCase() === targetKey.toLowerCase();
+};


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Refactor code to use a centralized keymap for all keyboard shortcuts

Based on Manas's excellent suggestion at https://github.com/defog-ai/agents-ui-components/pull/102#issuecomment-2612936072

Windsurf did all the work. I just copy pasted Manas's suggestion with some context

```
we currently have some keyboard shortcuts defined in StepResultsTable.tsx and DraggableInput.tsx

Since we have shortcuts for things in various places in the codebase, it might be worth declaring them as constants somewhere and using those.

Having keymap defined in one place and using those variables would make it easy easy to change things!

Can you please help create this?
```
--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
