### PR TITLE
[Bugfix] Fix key hijacking for table search shortcut

### DIFF
--- a/lib/components/core-ui/Table.tsx
+++ b/lib/components/core-ui/Table.tsx
@@ -394,6 +394,14 @@ export function Table({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // Bail out early if user is typing in some input/textarea that is NOT the table's search input
+      const isOutsideTableSearch =
+        (e.target instanceof HTMLInputElement &&
+          e.target !== searchInputRef.current) ||
+        e.target instanceof HTMLTextAreaElement ||
+        (e.target as HTMLElement).isContentEditable;
+      if (isOutsideTableSearch) return;
+
       if (
         e.target instanceof HTMLInputElement ||
         (e.target as HTMLElement).isContentEditable


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Bugfix for key hijacking

The table search shortcut was triggering even if the 's' key was pressed in an input or textarea element that was focused. So asking a question with an 's' character in the main "ask" bar would trigger search blur instead of actually being typed in the main question.

Fixed now!


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
