### PR TITLE
Send auth token to csv routes

### DIFF
--- a/lib/components/agent/analysis/analysisManager.ts
+++ b/lib/components/agent/analysis/analysisManager.ts
@@ -341,7 +341,7 @@ function createAnalysisManager({
     // then create analysis data object with the required format
     // or if it's an error, then tool_run_details = {error_message: error}
     else if (sqlOnly && isTemp) {
-      const step = await generateStepForCsv(question, sqliteConn);
+      const step = await generateStepForCsv(question, sqliteConn, token);
 
       console.log(step);
 
@@ -707,7 +707,8 @@ function createAnalysisManager({
 
   async function generateStepForCsv(
     question: string,
-    sqliteConn: any
+    sqliteConn: any,
+    token: string | null
   ): Promise<Step> {
     const res = await generateQueryForCsv({
       question: question,
@@ -722,6 +723,7 @@ function createAnalysisManager({
       keyName: keyName,
       apiEndpoint: apiEndpoint,
       previousContext: previousContext,
+      token,
     });
 
     const stepId = crypto.randomUUID();
@@ -758,6 +760,7 @@ function createAnalysisManager({
         apiEndpoint: apiEndpoint,
         previousQuery: res.sql,
         error: previousError,
+        token,
       });
 
       if (retryRes.error_message || !retryRes.success) {
@@ -851,7 +854,11 @@ function createAnalysisManager({
 
     if (currentQuestion !== originalQuestion) {
       // generate a new step
-      const newStep = await generateStepForCsv(currentQuestion, sqliteConn);
+      const newStep = await generateStepForCsv(
+        currentQuestion,
+        sqliteConn,
+        token
+      );
       newAnalysisData.gen_steps.steps = [newStep];
       setAnalysisData(newAnalysisData);
     } else {

--- a/lib/components/defog-analysis-agent-embed/DefogAnalysisAgentEmbed.jsx
+++ b/lib/components/defog-analysis-agent-embed/DefogAnalysisAgentEmbed.jsx
@@ -188,6 +188,7 @@ export function EmbedInner({
         keyName: csvFileKeyName,
         metadata: metadata,
         tableName: sqliteTableName,
+        token,
       });
 
       if (!res.success || res.error_message || !res.descriptions) {

--- a/lib/components/utils/utils.js
+++ b/lib/components/utils/utils.js
@@ -419,6 +419,7 @@ export async function getColumnDescriptionsForCsv({
   keyName,
   metadata,
   tableName,
+  token,
 }) {
   const urlToConnect = setupBaseUrl({
     protocol: "http",
@@ -440,6 +441,7 @@ export async function getColumnDescriptionsForCsv({
           column_name: d.column_name,
         })),
         table_name: tableName,
+        token,
       }),
     });
 
@@ -462,6 +464,7 @@ export async function getColumnDescriptionsForCsv({
  * @param {?Array<{ column_name: string, data_type: string, table_name: string }>} params.metadata - Metadata of the columns
  * @param {string} params.apiEndpoint - API endpoint
  * @param {PreviousContext} params.previousContext - Previous context
+ * @param {string} params.token - Token
  *
  * @returns {Promise<{ success: boolean, error_message?: string, sql?: string }>}
  */
@@ -471,6 +474,7 @@ export const generateQueryForCsv = async ({
   metadata,
   apiEndpoint,
   previousContext = [],
+  token,
 }) => {
   const urlToConnect = setupBaseUrl({
     protocol: "http",
@@ -492,6 +496,7 @@ export const generateQueryForCsv = async ({
         db_type: "sqlite",
         metadata,
         previous_context: previousContext,
+        token,
       }),
     });
 
@@ -518,6 +523,7 @@ export const generateQueryForCsv = async ({
  * @param {string} params.apiEndpoint - API endpoint
  * @param {string} params.previousQuery - Previous query
  * @param {string|null} params.error - Error message
+ * @param {string|null} params.token - Token
  *
  * @returns {Promise<{ success: boolean, error_message?: string, sql?: string }>}
  */
@@ -528,6 +534,7 @@ export const retryQueryForCsv = async ({
   apiEndpoint,
   previousQuery,
   error,
+  token,
 }) => {
   const urlToConnect = setupBaseUrl({
     protocol: "http",
@@ -552,6 +559,7 @@ export const retryQueryForCsv = async ({
         metadata,
         previous_query: previousQuery,
         error: error,
+        token,
       }),
     });
 


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Auth to CSV routes

Previously, we were not sending any token for authentication to the CSV routes. We send those now.

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
