### PR TITLE
Bring back `StepOutputs` to show sql query generated

### DIFF
--- a/lib/components/agent/analysis/step-results/StepOutputs.jsx
+++ b/lib/components/agent/analysis/step-results/StepOutputs.jsx
@@ -1,0 +1,29 @@
+import { CodeEditor } from "./CodeEditor";
+
+export function StepOutputs({
+  analysisId,
+  stepId,
+  sql = null,
+  handleEdit = (...args) => {},
+}) {
+  return (
+    <div className="tool-output-list text-xs font-mono">
+      <div className="tool-code mt-8">
+        {sql && (
+          <>
+            <p className="mb-2 font-bold text-sm">SQL</p>
+            <CodeEditor
+              key={sql}
+              className="tool-code-ctr"
+              analysisId={analysisId}
+              stepId={stepId}
+              code={sql}
+              handleEdit={handleEdit}
+              updateProp={"sql"}
+            ></CodeEditor>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/components/agent/analysis/step-results/StepResults.tsx
+++ b/lib/components/agent/analysis/step-results/StepResults.tsx
@@ -105,6 +105,15 @@ export function StepResults({
                 handleEdit={handleEdit}
               ></StepInputs>
             </div>
+            <div className="my-4">
+              <p className="mb-4 text-xs text-gray-400">OUTPUTS</p>
+              <StepOutputs
+                analysisId={analysisId}
+                stepId={stepId}
+                sql={step?.sql}
+                handleEdit={handleEdit}
+              ></StepOutputs>
+            </div>
             {step?.sql && (
               // get feedback from user if the sql is good or not
               <>


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

Dumb mistake from my end. SQL generated is shown again now.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/d31c3274-6e09-4816-a3d1-04198a304d01" />


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
