### PR TITLE
remove tool stuff

### DIFF
--- a/lib/components/agent/analysis/AnalysisAgent.tsx
+++ b/lib/components/agent/analysis/AnalysisAgent.tsx
@@ -84,7 +84,7 @@ interface Props {
    */
   searchBarPlaceholder?: string | null;
   /**
-   * if this analysis uses any extra tools. Used in the add tool UI.
+   * if this analysis uses any extra tools. Used in the add tool UI to create a test analysis.
    */
   extraTools?: Array<{
     code: string;
@@ -95,7 +95,7 @@ interface Props {
     output_metadata: object;
   }>;
   /**
-   * suffix for the planner model's question. Used in the add tool UI.
+   * suffix for the planner model's question. Used in the add tool UI to create a test analysis.
    */
   plannerQuestionSuffix?: string | null;
   /**
@@ -214,8 +214,6 @@ export const AnalysisAgent = ({
   // in case this isn't called from analysis tree viewer (which has a central singular search bar)
   // we will have an independent search bar for each analysis as well
   const independentAnalysisSearchRef = useRef<HTMLInputElement>(null);
-
-  const [tools, setTools] = useState({});
 
   const ctr = useRef<HTMLDivElement>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
@@ -597,7 +595,6 @@ export const AnalysisAgent = ({
                                   ),
                                 };
                               }}
-                              tools={tools}
                               analysisBusy={analysisBusy}
                               setCurrentQuestion={setCurrentQuestion}
                               analysisTreeManager={

--- a/lib/components/agent/analysis/step-results/StepResults.tsx
+++ b/lib/components/agent/analysis/step-results/StepResults.tsx
@@ -32,8 +32,6 @@ export function StepResults({
   handleReRun = (...args: any[]) => {},
   reRunningSteps = [],
   updateStepData = (...args: any[]) => {},
-  // toolRunDataCache = {},
-  tools = {},
   analysisBusy = false,
   setCurrentQuestion = (...args: any[]) => {},
   analysisTreeManager = null,
@@ -47,8 +45,6 @@ export function StepResults({
   handleReRun: (...args: any[]) => void;
   reRunningSteps: Step[];
   updateStepData: (stepId: string, update: Record<string, any>) => void;
-  // toolRunDataCache: any;
-  tools: any;
   analysisBusy: boolean;
   setCurrentQuestion: (...args: any[]) => void;
   analysisTreeManager: AnalysisTreeManager;

--- a/lib/components/context/AgentContext.tsx
+++ b/lib/components/context/AgentContext.tsx
@@ -12,7 +12,6 @@ export interface AgentConfig {
   analyses: any[];
   dashboards: any[];
   analysisDataCache: any;
-  toolRunDataCache: any;
   showAnalysisUnderstanding: boolean;
   showCode: boolean;
   allowDashboardAdd: boolean;
@@ -33,7 +32,6 @@ export const defaultAgentConfig: AgentConfig = {
   analyses: [],
   dashboards: [],
   analysisDataCache: {},
-  toolRunDataCache: {},
   showAnalysisUnderstanding: true,
   showCode: true,
   allowDashboardAdd: true,
@@ -42,7 +40,9 @@ export const defaultAgentConfig: AgentConfig = {
 /**
  * Create agent configuration.
  */
-export function createAgentConfig(partialConfig: Partial<AgentConfig> = {}): AgentConfig {
+export function createAgentConfig(
+  partialConfig: Partial<AgentConfig> = {}
+): AgentConfig {
   // only set defined keys
   const newConfig = Object.assign({}, defaultAgentConfig);
 
@@ -54,7 +54,6 @@ export function createAgentConfig(partialConfig: Partial<AgentConfig> = {}): Age
 
   return newConfig;
 }
-
 
 // defining this so explicitly here only to allow vscode's intellisense to work
 // we can also just do createContext()

--- a/lib/components/utils/utils.js
+++ b/lib/components/utils/utils.js
@@ -108,10 +108,6 @@ export const toolDisplayNames = {
   data_fetcher_and_aggregator: "Fetch data from db",
 };
 
-export const toolShortNames = {
-  data_fetcher_and_aggregator: "SQL ",
-};
-
 export const easyToolInputTypes = {
   DBColumn: "Column name",
   DBColumnList: "List of column names",


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

Removes a few more props/comments related to tools. Keeps the `extraTools` and `plannerQuestionSuffix` props for now (which are used when a new tool is being tested from DSH)

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
