### PR TITLE
Fix singleselect highlight index for dark mode

### DIFF
--- a/lib/components/core-ui/SingleSelect.jsx
+++ b/lib/components/core-ui/SingleSelect.jsx
@@ -310,7 +310,7 @@ export function SingleSelect({
                   "cursor-pointer select-none relative py-2 pl-3 pr-9 truncate",
                   popupOptionSizeClasses[size] ||
                     popupOptionSizeClasses["default"],
-                  highlightIndex === idx ? "bg-blue-100" : ""
+                  highlightIndex === idx ? "bg-blue-100 dark:bg-blue-900/50" : ""
                 )}
                 onMouseDown={(e) => {
                   e.preventDefault();


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Dark Mode fix for SingleSelect

Active element looked off in dark mode. Fixed now!

<img width="254" alt="image" src="https://github.com/user-attachments/assets/0b3d96a7-1387-4007-9ad8-5722d881bda6" />


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
