### PR TITLE
Fix dark mode chart exports

### DIFF
--- a/lib/components/observable-charts/utils/saveChart.js
+++ b/lib/components/observable-charts/utils/saveChart.js
@@ -21,8 +21,8 @@ export function saveAsPNG(container, options = {}) {
   } = options;
 
   const PADDING = 0;
-
-  // Capture original styles
+  
+  // Store original styles including text colors and backgrounds
   const originalStyles = {
     width: container.style.width,
     height: container.style.height,
@@ -33,7 +33,19 @@ export function saveAsPNG(container, options = {}) {
     padding: container.style.padding,
     scrollTop: container.scrollTop,
     scrollLeft: container.scrollLeft,
+    backgroundColor: container.style.backgroundColor,
   };
+
+  // Store original text colors of all text elements
+  const textElements = container.querySelectorAll('text, .tick text, .axis-label, .title');
+  const originalTextColors = new Map();
+  textElements.forEach(el => {
+    originalTextColors.set(el, {
+      fill: el.style.fill || window.getComputedStyle(el).fill,
+      stroke: el.style.stroke || window.getComputedStyle(el).stroke,
+      color: el.style.color || window.getComputedStyle(el).color
+    });
+  });
 
   // Prepare container for capture
   const prepareContainer = () => {
@@ -45,9 +57,17 @@ export function saveAsPNG(container, options = {}) {
       transform: "none",
       transformOrigin: "top left",
       padding: `${PADDING}px`,
+      backgroundColor: bg,
     });
     container.scrollTop = 0;
     container.scrollLeft = 0;
+
+    // Set all text elements to dark color for light background
+    textElements.forEach(el => {
+      el.style.fill = '#000000';
+      el.style.stroke = 'none';
+      el.style.color = '#000000';
+    });
   };
 
   // Restore container to original state
@@ -60,9 +80,20 @@ export function saveAsPNG(container, options = {}) {
       transform: originalStyles.transform,
       transformOrigin: originalStyles.transformOrigin,
       padding: originalStyles.padding,
+      backgroundColor: originalStyles.backgroundColor,
     });
     container.scrollTop = originalStyles.scrollTop;
     container.scrollLeft = originalStyles.scrollLeft;
+
+    // Restore original text colors
+    textElements.forEach(el => {
+      const originalColors = originalTextColors.get(el);
+      if (originalColors) {
+        el.style.fill = originalColors.fill;
+        el.style.stroke = originalColors.stroke;
+        el.style.color = originalColors.color;
+      }
+    });
   };
 
   try {


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

### Details

Previously, charts exported when in dark mode caused had a white background but also white text - like here

![chart (11)](https://github.com/user-attachments/assets/8c90c782-b8de-4094-9fe6-2e6395ba5caa)

Fixed in this PR! We keep export colors "light mode friendly" all the time now.
![chart (13)](https://github.com/user-attachments/assets/f028bb63-bfd2-492f-9135-9ad8bb446a0b)


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
