### PR TITLE
remove import.meta.vite_token from oracleembed. pass it as a prop

### DIFF
--- a/lib/components/oracle/reports/OracleEmbed.tsx
+++ b/lib/components/oracle/reports/OracleEmbed.tsx
@@ -55,7 +55,13 @@ const findReportGroupInHistory = (
  * This has a sidebar to select api key names, and a report selector which shows a list of already generated reports.
  * Has a button to start a new report.
  */
-export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
+export function OracleEmbed({
+  apiEndpoint,
+  token,
+}: {
+  apiEndpoint: string;
+  token: string;
+}) {
   const [keyNames, setKeyNames] = useState([]);
   const [selectedApiKeyName, setSelectedApiKeyName] = useState("Default DB");
   const [reportHistory, setReportHistory] = useState<ReportHistory>({});
@@ -65,14 +71,10 @@ export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
 
   const messageManager = useRef(MessageManager());
 
-  const token = useRef<string>(
-    localStorage.getItem("defogToken") || import.meta.env.VITE_TOKEN
-  );
-
   useEffect(() => {
     async function setup() {
       try {
-        const keyNames = await getApiKeyNames(token.current);
+        const keyNames = await getApiKeyNames(token);
         if (!keyNames) throw new Error("Failed to get api key names");
         setKeyNames(keyNames);
 
@@ -98,11 +100,7 @@ export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
           };
 
           try {
-            const reports = await fetchReports(
-              apiEndpoint,
-              token.current,
-              keyName
-            );
+            const reports = await fetchReports(apiEndpoint, token, keyName);
             if (!reports) throw new Error("Failed to get reports");
 
             reports
@@ -244,7 +242,7 @@ export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
               reportId={selectedReportId}
               apiEndpoint={apiEndpoint}
               keyName={selectedApiKeyName}
-              token={token.current}
+              token={token}
               onDelete={async () => {
                 const reportGroup = findReportGroupInHistory(
                   selectedApiKeyName,
@@ -254,7 +252,7 @@ export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
                 const deleteSucess = await deleteReport(
                   apiEndpoint,
                   selectedReportId,
-                  token.current,
+                  token,
                   selectedApiKeyName
                 );
 
@@ -328,7 +326,7 @@ export function OracleEmbed({ apiEndpoint }: { apiEndpoint: string }) {
                 )}
               >
                 <OracleDraftReport
-                  token={token.current}
+                  token={token}
                   apiKeyName={keyName}
                   apiEndpoint={apiEndpoint}
                   onReportGenerated={(userQuestion, reportId, status) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/test/oracle/test-oracle-embed.tsx
+++ b/test/oracle/test-oracle-embed.tsx
@@ -5,7 +5,10 @@ import "../../lib/styles/index.scss";
 function OracleEmbedTest() {
   return (
     <div className="h-screen">
-      <OracleEmbed apiEndpoint={import.meta.env.VITE_API_ENDPOINT} />
+      <OracleEmbed
+        apiEndpoint={import.meta.env.VITE_API_ENDPOINT}
+        token={import.meta.env.VITE_TOKEN}
+      />
     </div>
   );
 }


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** <OracleEmbed/> needs a token prop now
- **Regression:** None

--

Publishes 1.1.47

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
