### PR TITLE
Manas/ux fixes

### DIFF
--- a/lib/components/core-ui/SingleSelect.tsx
+++ b/lib/components/core-ui/SingleSelect.tsx
@@ -274,11 +274,11 @@ export function SingleSelect({
           type="text"
           placeholder={placeholder}
           className={twMerge(
-            "w-full rounded-md border-0 pr-12 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-400 dark:focus:ring-blue-500 sm:text-sm sm:leading-6 hover:ring-2 hover:ring-inset hover:ring-blue-400 dark:hover:ring-blue-500 hover:cursor-pointer",
+            "w-full rounded-md border-0 pr-12 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-400 sm:text-sm sm:leading-6 ",
             inputSizeClasses[size] || inputSizeClasses["default"],
             disabled
               ? "bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 dark:ring-gray-700 cursor-not-allowed hover:cursor-not-allowed"
-              : "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              : "bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-inset focus:ring-blue-400 dark:focus:ring-blue-500 hover:ring-2 hover:ring-inset hover:ring-blue-400 dark:hover:ring-blue-500 hover:cursor-pointer"
           )}
           value={
             query !== null

--- a/lib/components/core-ui/TextArea.tsx
+++ b/lib/components/core-ui/TextArea.tsx
@@ -117,7 +117,7 @@ let TextArea = forwardRef(function TextArea(
           {label}
         </label>
       )}
-      <div className="relative p-2">
+      <div className="relative">
         {prefix && (
           <div className="text-gray-400 text-[0.65rem] dark:text-gray-100 pb-3">
             {prefix}

--- a/lib/components/oracle/embed/OracleEmbed.tsx
+++ b/lib/components/oracle/embed/OracleEmbed.tsx
@@ -223,14 +223,6 @@ export function OracleEmbed({
   const dbSelector = useMemo(
     () => (
       <>
-        {/* {hasUploadedDataFiles ? (
-          <div className="flex flex-row items-start gap-2 w-full text-xs mb-4 text-blue-600 dark:text-blue-300">
-            <Info className="w-4 min-w-4" />
-            <span>
-              A new database will be created using your uploaded csv/excel files
-            </span>
-          </div>
-        ) : null} */}
         <SingleSelect
           label="Select Database"
           rootClassNames="mb-2"
@@ -270,9 +262,29 @@ export function OracleEmbed({
             dataFiles && dataFiles?.length ? true : false
           );
         }}
-        onReportGenerated={(userQuestion, reportId, status, newDbName) => {
+        onClarified={(newDbName) => {
+          if (newDbName) {
+            messageManager.current.success(`Database ${newDbName} created`);
+            setDbNames((prev) => [...prev, newDbName]);
+            setSelectedDbName(newDbName);
+            setSelectedReportId(null);
+            setReportHistory((prev) => ({
+              ...prev,
+              [newDbName]: {
+                Today: [],
+                Yesterday: [],
+                "Past week": [],
+                "Past month": [],
+                Earlier: [],
+              },
+            }));
+          }
+        }}
+        onReportGenerated={({ userQuestion, reportId, status, newDbName }) => {
           setReportHistory((prev) => {
             let newHistory: ReportHistory = { ...prev };
+
+            console.log(newDbName, selectedDbName);
 
             if (newDbName) {
               newHistory = {

--- a/lib/components/oracle/embed/OracleEmbed.tsx
+++ b/lib/components/oracle/embed/OracleEmbed.tsx
@@ -16,7 +16,7 @@ import {
   ReportData,
   ListReportResponseItem,
 } from "@oracle";
-import { Info, SquarePen, TriangleAlert } from "lucide-react";
+import { Info, SquarePen } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { OracleDraftReport } from "../reports/report-creation/OracleDraftReport";
 import { OracleNewDb } from "./OracleNewDb";
@@ -222,12 +222,16 @@ export function OracleEmbed({
 
   const dbSelector = useMemo(
     () => (
-      <>
+      <div>
         <SingleSelect
-          label="Select Database"
+          label={
+            !selectedReportId && hasUploadedDataFiles
+              ? "Remove uploaded CSV/Excel files to select a database"
+              : "Select Database"
+          }
           rootClassNames="mb-2"
           value={selectedDbName}
-          disabled={hasUploadedDataFiles}
+          disabled={selectedReportId === null && hasUploadedDataFiles}
           allowClear={false}
           allowCreateNewOption={false}
           options={[
@@ -246,9 +250,9 @@ export function OracleEmbed({
             setSelectedReportId(null);
           }}
         />
-      </>
+      </div>
     ),
-    [selectedDbName, dbNames, hasUploadedDataFiles]
+    [selectedDbName, selectedReportId, dbNames, hasUploadedDataFiles]
   );
 
   const draftReport = useMemo(() => {

--- a/lib/components/oracle/reports/report-creation/OracleDraftReport.tsx
+++ b/lib/components/oracle/reports/report-creation/OracleDraftReport.tsx
@@ -65,17 +65,19 @@ export function OracleDraftReport({
   dbName,
   token,
   onReportGenerated,
+  onClarified = () => {},
   onUploadDataFiles = () => {},
 }: {
   apiEndpoint: string;
   dbName: string;
   token: string;
-  onReportGenerated?: (
-    userQuestion: string,
-    reportId: string,
-    status: string,
-    newDbName?: string
-  ) => void;
+  onClarified?: (newDbName?: string) => void;
+  onReportGenerated?: (data: {
+    userQuestion: string;
+    reportId: string;
+    status: string;
+    newDbName?: string;
+  }) => void;
   onUploadDataFiles?: (dataFiles?: UploadedFile[]) => void;
 }) {
   const [draft, setDraft] = useState<ReportDraft>({
@@ -118,14 +120,13 @@ export function OracleDraftReport({
         );
       } catch (error) {
         message.success("Report submitted for generation");
+        onReportGenerated({
+          userQuestion: textAreaRef.current?.value || draft.userQuestion,
+          reportId: reportId,
+          status: ORACLE_REPORT_STATUS.THINKING,
+          newDbName: newDbName.current,
+        });
       }
-
-      onReportGenerated(
-        textAreaRef.current?.value || draft.userQuestion,
-        reportId,
-        ORACLE_REPORT_STATUS.THINKING,
-        newDbName.current
-      );
 
       // clear everything
       setDraft({
@@ -532,6 +533,7 @@ export function OracleDraftReport({
                     if (res.new_db_name && res.new_db_info) {
                       newDbName.current = res.new_db_name;
                       newDbInfo.current = res.new_db_info;
+                      onClarified(newDbName.current);
                     }
                   } catch (e) {
                     message.error("Error getting clarifications");

--- a/lib/components/oracle/reports/report-creation/OracleDraftReport.tsx
+++ b/lib/components/oracle/reports/report-creation/OracleDraftReport.tsx
@@ -337,7 +337,7 @@ export function OracleDraftReport({
             <TextArea
               prefix={UploadedFileIcons}
               ref={textAreaRef}
-              rootClassNames="w-full h-full rounded-xl border dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700 overflow-hidden"
+              rootClassNames="p-2 w-full h-full rounded-xl border dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700 overflow-hidden"
               textAreaClassNames="border-0 outline-0 ring-0 shadow-none focus:ring-0"
               suffix={
                 <div className="flex flex-col">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

Some minor UX improvements:
1. Change to the newly created db when we receive clarifications.
2. Create a report when we submit as usual.
3. Now change the label of the main single select when it is disabled because CSVs/Excels have been uploaded.

<img width="983" alt="image" src="https://github.com/user-attachments/assets/fdc80a04-7b89-4473-80b7-984304464349" />


<img width="920" alt="image" src="https://github.com/user-attachments/assets/2f6fdd32-bb9d-49c3-bf17-b1e2fa034b01" />


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
