### PR TITLE
fix other/new option selection via keyboard and mouse

### DIFF
--- a/lib/components/core-ui/SingleSelect.tsx
+++ b/lib/components/core-ui/SingleSelect.tsx
@@ -165,10 +165,10 @@ export function SingleSelect({
   const ref = useRef(null);
 
   // Process options, adding an "Other" option if showOtherOption is true
-  const processedOptions = showOtherOption 
+  const processedOptions = showOtherOption
     ? [...options, { value: "__other__", label: otherOptionLabel }]
     : options;
-    
+
   const [internalOptions, setInternalOptions] = useState(
     processedOptions.map((d) => ({
       value: isNumber(d.value) ? +d.value : d.value,
@@ -178,10 +178,10 @@ export function SingleSelect({
   );
 
   useEffect(() => {
-    const opts = showOtherOption 
+    const opts = showOtherOption
       ? [...options, { value: "__other__", label: otherOptionLabel }]
       : options;
-      
+
     setInternalOptions(
       opts.map((d) => ({
         value: isNumber(d.value) ? +d.value : d.value,
@@ -330,7 +330,9 @@ export function SingleSelect({
           }}
           onFocus={() => {
             if (disabled) return;
-            setOpen(true);
+            if (!isOtherSelected) {
+              setOpen(true);
+            }
           }}
           onBlur={() => {
             setTimeout(() => {
@@ -338,9 +340,9 @@ export function SingleSelect({
               if (isOtherSelected && !customValue) {
                 setIsOtherSelected(false);
                 setSelectedOption(null);
+                setQuery(null);
               }
             }, 200);
-            setQuery(null);
           }}
           readOnly={disabled && !isOtherSelected}
           onKeyDown={(e) => {
@@ -366,7 +368,7 @@ export function SingleSelect({
               e.preventDefault();
               if (open && filteredOptions.length > 0 && highlightIndex >= 0) {
                 const option = filteredOptions[highlightIndex];
-                
+
                 if (option.value === "__other__" && showOtherOption) {
                   setIsOtherSelected(true);
                   setSelectedOption(option);

--- a/stories/core-ui/SingleSelect.stories.tsx
+++ b/stories/core-ui/SingleSelect.stories.tsx
@@ -8,8 +8,13 @@ export default {
   },
   tags: ["autodocs"],
   argTypes: {
-    onChange: { action: "changed" }
-  }
+    onChange: { action: "changed" },
+  },
+  render: (args) => (
+    <div className="h-96 ">
+      <SingleSelect {...args} />
+    </div>
+  ),
 };
 
 export const Default = {
@@ -113,8 +118,8 @@ export const NoAllowCreateNewOption = {
 export const WithOtherOption = {
   args: {
     options: [
-      { value: "apple", label: "Apple" },
       { value: "banana", label: "Banana" },
+      { value: "apple", label: "Apple" },
       { value: "cherry", label: "Cherry" },
     ],
     showOtherOption: true,


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

Loads of hackery here, but the couple issues were:
1. The browser would call an extra blur event when we selected the "other" option via the keyboard (perhaps due to the keyUp event being bound to the `<input>` and not the `<li>`). Fixed by using an `ignoreBlur` ref variable which is set to true inside the keyup handler. If `ignoreBlur` is true inside the `onBlur` handler, we simply return from it.
3. Clicking away _without_ selecting the newly created option when `Other` is selected: We now reset the state _back_ to what it was _before_ other was selected. We store this inside an `optionSelectedBeforeClickingOther` ref.
2. Fix flicker by adding more conditions to the blur and focus events.
4. Small style improvements to disabled state

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
