### PR TITLE
Better loading status in file upload (in a very stupid way though)

### DIFF
--- a/lib/components/core-ui/DropFiles.tsx
+++ b/lib/components/core-ui/DropFiles.tsx
@@ -129,24 +129,31 @@ export function DropFiles({
             {selectedFiles.map((file, index) => (
               <div
                 key={`${file.name}-${index}`}
-                className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded-lg px-3 py-2 text-sm"
+                className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 rounded-lg px-3 py-2 text-sm text-gray-500 dark:text-gray-400"
               >
                 <div className="flex items-center max-w-[85%]">
                   <File className="w-4 h-4 mr-2 flex-shrink-0" />
                   <span className="truncate">{file.name}</span>
                 </div>
                 <div className="flex items-center">
-                  <span className="text-xs text-gray-500 dark:text-gray-400 mx-2">
+                  <span className="text-xs mx-2">
                     {formatFileSize(file.size)}
                   </span>
                   {onRemoveFile && (
                     <button
                       type="button"
                       onClick={(e) => {
+                        if (disabled) return;
+
                         e.stopPropagation();
                         onRemoveFile(index);
                       }}
-                      className="ml-1 text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400"
+                      className={twMerge(
+                        "ml-1",
+                        !disabled
+                          ? "hover:text-red-500 dark:hover:text-red-400"
+                          : "text-gray-300 dark:text-gray-600 opacity-0"
+                      )}
                     >
                       <XCircle className="w-4 h-4" />
                     </button>
@@ -175,7 +182,10 @@ export function DropFiles({
         multiple={allowMultiple}
         aria-label=""
         accept={acceptedFileTypes.join(",")}
-        className="w-full h-full z-[1] opacity-0 absolute left-0 top-0 cursor-pointer"
+        className={twMerge(
+          "w-full h-full z-[1] opacity-0 absolute left-0 top-0",
+          disabled ? "cursor-not-allowed" : "cursor-pointer"
+        )}
         type="file"
         title="Click to select file"
         disabled={disabled}

--- a/lib/components/oracle/embed/OracleEmbed.tsx
+++ b/lib/components/oracle/embed/OracleEmbed.tsx
@@ -753,7 +753,7 @@ export function OracleEmbed({
   const wasUploaded = useRef(false);
 
   useEffect(() => {
-    if (wasUploaded.current) {
+    if (wasUploaded.current && dbNames.length) {
       setSelectedDbName(dbNames[dbNames.length - 1]);
     }
     wasUploaded.current = false;

--- a/lib/components/oracle/embed/OracleEmbed.tsx
+++ b/lib/components/oracle/embed/OracleEmbed.tsx
@@ -750,6 +750,15 @@ export function OracleEmbed({
     selectedItem,
   ]);
 
+  const wasUploaded = useRef(false);
+
+  useEffect(() => {
+    if (wasUploaded.current) {
+      setSelectedDbName(dbNames[dbNames.length - 1]);
+    }
+    wasUploaded.current = false;
+  }, [dbNames]);
+
   if (error) {
     return (
       <div className="w-screen h-screen flex items-center justify-center bg-rose-50 text-rose-500">
@@ -802,7 +811,7 @@ export function OracleEmbed({
                       },
                     }));
                     setDbNames((prev) => [...prev, dbName]);
-                    setSelectedDbName(dbName);
+                    wasUploaded.current = true;
                   }}
                 />
               )}

--- a/lib/components/oracle/embed/OracleNewDb.tsx
+++ b/lib/components/oracle/embed/OracleNewDb.tsx
@@ -12,6 +12,11 @@ import {
 import { useContext, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
+const timeouts = [
+  { message: "Checking format...", time: 4000 },
+  { message: "Cleaning formatting niggles...", time: 10000 },
+];
+
 export const OracleNewDb = ({
   apiEndpoint,
   token,
@@ -109,9 +114,13 @@ export const OracleNewDb = ({
             console.time("OracleNewDb:uploadFiles");
             setLoading(true);
 
-            const timeout = setTimeout(() => {
-              setLoadingMessage("Cleaning formatting niggles...");
-            }, 4000);
+            const timeoutIds = timeouts.map(({ message, time }) => {
+              return setTimeout(() => {
+                setLoadingMessage(message);
+              }, time);
+            });
+
+            setLoadingMessage("Sending to servers");
 
             const { dbName } = await uploadMultipleFilesAsDb(
               apiEndpoint,
@@ -119,7 +128,7 @@ export const OracleNewDb = ({
               selectedFiles
             );
 
-            clearTimeout(timeout);
+            timeoutIds.forEach(clearTimeout);
 
             message.success(`DB ${dbName} created successfully`);
             onDbCreated(dbName);


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

Change loading messages depending on time passed. Really stupid but okay for now.

<img width="994" alt="image" src="https://github.com/user-attachments/assets/794a9340-db7a-418c-b7f6-47ade5122b64" />


<img width="1121" alt="image" src="https://github.com/user-attachments/assets/d2fb836a-6ecf-4c05-9324-d06da0a312c9" />


<img width="942" alt="image" src="https://github.com/user-attachments/assets/ad7c0acb-b9fc-4e25-bf8e-cff39b74c229" />


--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
