### PR TITLE
Allow typing Slash in search bar + other UX fixes 

### DIFF
--- a/lib/components/core-ui/Menu.tsx
+++ b/lib/components/core-ui/Menu.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { Button } from "@ui-components";
+import { Button } from "./Button";
 
 /**
  * Props for the MenuItem component

--- a/lib/components/hooks/useKeyDown.tsx
+++ b/lib/components/hooks/useKeyDown.tsx
@@ -16,7 +16,7 @@ export const useKeyDown = (
     shift?: boolean;
     alt?: boolean;
     target?: HTMLElement;
-    callback: () => void;
+    callback: (event: KeyboardEvent) => void;
   },
   deps: any[] = []
 ) => {
@@ -39,7 +39,7 @@ export const useKeyDown = (
       ) {
         keyboardEvent.stopPropagation();
         keyboardEvent.preventDefault();
-        callback();
+        callback(keyboardEvent);
       }
     };
 

--- a/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
+++ b/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
@@ -272,7 +272,7 @@ export function OracleSearchBar({
 
   // Handle keyboard shortcuts using the useKeyDown hook
 
-  // Focus search with "cmd+/"
+  // Focus search with "/"
   useKeyDown(
     {
       key: KEYMAP.FOCUS_ORACLE_SEARCH,

--- a/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
+++ b/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
@@ -272,11 +272,15 @@ export function OracleSearchBar({
 
   // Handle keyboard shortcuts using the useKeyDown hook
 
-  // Focus search with "/"
+  // Focus search with "cmd+/"
   useKeyDown(
     {
       key: KEYMAP.FOCUS_ORACLE_SEARCH,
-      callback: () => {
+      callback: (e) => {
+        // don't focus on report view or "upload new" view (browser does weird stuff if we focus off screen things)
+        if (dbName === uploadNewDbOption || selectedItem?.itemType === "report")
+          return;
+
         textAreaRef.current?.focus();
       },
     },
@@ -386,7 +390,7 @@ export function OracleSearchBar({
   return (
     <div
       className={twMerge(
-        "transition-all duration-700 ease-in-out z-[10] *:transition-all *:duration-700 *:ease-in-out",
+        "oracle-search transition-all duration-700 ease-in-out z-[10] *:transition-all *:duration-700 *:ease-in-out",
         itemTypeClasses[
           selectedItem?.itemType ||
             (dbName === uploadNewDbOption ? "new-db" : "default")
@@ -394,7 +398,7 @@ export function OracleSearchBar({
       )}
     >
       {errorMessage && (
-        <div className="mb-4">
+        <div className="mb-4 absolute -top-16">
           <AlertBanner
             type="error"
             message={errorMessage}
@@ -675,6 +679,8 @@ export function OracleSearchBar({
             style: { resize: "none" },
           }}
           onKeyDown={async (e) => {
+            // allow slash typing
+            e.stopPropagation();
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               const question = e.currentTarget.value;
               if (!question) {

--- a/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
+++ b/lib/components/oracle/embed/search-bar/OracleSearchBar.tsx
@@ -679,8 +679,10 @@ export function OracleSearchBar({
             style: { resize: "none" },
           }}
           onKeyDown={async (e) => {
-            // allow slash typing
-            e.stopPropagation();
+            // only do this for slash
+            if (e.key === "/") {
+              e.stopPropagation();
+            }
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               const question = e.currentTarget.value;
               if (!question) {

--- a/lib/components/query-data/embed/QueryDataEmbed.tsx
+++ b/lib/components/query-data/embed/QueryDataEmbed.tsx
@@ -21,10 +21,9 @@ import {
 } from "../../context/QueryDataEmbedContext";
 import { QueryDataNewDb } from "./QueryDataNewDb";
 import ErrorBoundary from "../../../../lib/components/common/ErrorBoundary";
-import { AnalysisTreeViewer } from "@agent";
+import { AnalysisTreeViewer } from "../analysis-tree-viewer/AnalysisTreeViewer";
 import { getMetadata } from "@utils/utils";
 import { Tab, Tabs } from "../../../../lib/components/core-ui/Tabs";
-import { twMerge } from "tailwind-merge";
 
 interface EmbedProps {
   /**

--- a/lib/components/query-data/embed/QueryDataNewDb.tsx
+++ b/lib/components/query-data/embed/QueryDataNewDb.tsx
@@ -20,7 +20,7 @@ const UploadProgressBar = ({ progress }: { progress: number }) => {
         <span>{progress}%</span>
       </div>
       <div className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-        <div 
+        <div
           className="h-full bg-blue-500 transition-all duration-300 ease-out"
           style={{ width: `${progress}%` }}
         />
@@ -50,14 +50,9 @@ export const QueryDataNewDb = ({
     }
 
     console.time("QueryDataNewDb:uploadMultipleFilesAsDb");
-    const { dbName } = await uploadMultipleFilesAsDb(
-      apiEndpoint, 
-      token, 
-      [file],
-      (progress) => {
-        setUploadProgress(progress);
-      }
-    );
+    const { dbName } = await uploadMultipleFilesAsDb(apiEndpoint, token, [
+      file,
+    ]);
     console.timeEnd("QueryDataNewDb:uploadMultipleFilesAsDb");
 
     message.success(`DB ${dbName} created successfully`);
@@ -127,7 +122,10 @@ export const QueryDataNewDb = ({
       {loading && (
         <div className="flex flex-col w-full h-full items-center justify-center gap-4 text-gray-600 dark:text-gray-300">
           <div className="text-xs flex gap-1">
-            <SpinningLoader /> {uploadProgress > 0 ? `Uploading your file (${uploadProgress}%)` : "Uploading your file"}
+            <SpinningLoader />{" "}
+            {uploadProgress > 0
+              ? `Uploading your file (${uploadProgress}%)`
+              : "Uploading your file"}
           </div>
           {uploadProgress > 0 && (
             <div className="w-3/4 max-w-md">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
**Checklist:**

- **Breaking changes:** None
- **Regression:** None

--

From an issue reported by @Muhammad18557 :
> typing / in the question but that wasn’t working, and this triggers the focus option

1. pass event to callback in keydown
2. prevent slash from triggering usekeydown when typed from inside the search bar
3. don't trigger focus on new db option and when seeing reports
4. Make alerts appear just above search bar without pushing it down

--

<details>
  <summary>Instructions for reviewers</summary>

**For testing components:**

- Run `pnpm run dev` in your terminal
- Open `http://localhost:5173` in your browser, and select one of the components to see it in action.

Corresponding code for all those pages is inside `test/` folder.

Docs can be accessed via `pnpm run storybook` and visiting `http://localhost:6006`.

NOTE: Make sure to change the email to yours if testing the advanced mode. Look in basic-tests.spec.ts and replace manas@defog.ai with your email.

To run all tests in a backround browser: npx playwright test

To manually run tests: npx playwright test --ui

How to test with your own csv/excel files:

Paste the files into the playwright-tests/assets folders, and change the two variables: csvFileName and excelFileName inside playwright-tests/full-embed-tests/file-upload.spec.ts.
