### PR TITLE
Add support for report_with_citations in OracleReport component

### DIFF
--- a/lib/components/oracle/reports/OracleReport.tsx
+++ b/lib/components/oracle/reports/OracleReport.tsx
@@ -9,8 +9,9 @@ import {
   fetchAndParseReportData,
   OracleAnalysis,
   ReportData,
+  CitationItem
 } from "@oracle";
-import { LoadingState, ErrorState, AnalysisPanel } from "./components";
+import { LoadingState, ErrorState, AnalysisPanel, ReportCitationsContent } from "./components";
 
 export function OracleReport({
   apiEndpoint,
@@ -31,6 +32,7 @@ export function OracleReport({
   const [analyses, setAnalyses] = useState<OracleAnalysis[]>([]);
   const [comments, setComments] = useState<OracleReportComment[]>([]);
   const [mdx, setMDX] = useState<string | null>(null);
+  const [reportWithCitations, setReportWithCitations] = useState<CitationItem[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -60,6 +62,7 @@ export function OracleReport({
         data.parsed.tables && setTables(data.parsed.tables);
         data.analyses && setAnalyses(data.analyses);
         data.comments && setComments(data.comments);
+        data.report_with_citations && setReportWithCitations(data.report_with_citations);
 
         onReportParsed && onReportParsed(data);
       } catch (e: any) {
@@ -115,19 +118,26 @@ export function OracleReport({
     >
       <div className="flex flex-col lg:flex-row gap-4 relative overflow-auto">
         <div className="flex-1 relative oracle-report-ctr">
-          <EditorProvider
-            extensions={extensions}
-            content={mdx}
-            immediatelyRender={false}
-            editable={false}
-            slotBefore={<OracleNav onDelete={onDelete} />}
-            editorProps={{
-              attributes: {
-                class:
-                  "max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl oracle-report-tiptap relative prose prose-base dark:prose-invert mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0 focus:outline-none *:cursor-default",
-              },
-            }}
-          />
+          {reportWithCitations && reportWithCitations.length > 0 ? (
+            <div className="max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0">
+              <OracleNav onDelete={onDelete} />
+              <ReportCitationsContent citations={reportWithCitations} />
+            </div>
+          ) : (
+            <EditorProvider
+              extensions={extensions}
+              content={mdx}
+              immediatelyRender={false}
+              editable={false}
+              slotBefore={<OracleNav onDelete={onDelete} />}
+              editorProps={{
+                attributes: {
+                  class:
+                    "max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl oracle-report-tiptap relative prose prose-base dark:prose-invert mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0 focus:outline-none *:cursor-default",
+                },
+              }}
+            />
+          )}
         </div>
 
         {/* Analysis panel */}

--- a/lib/components/oracle/reports/components/ReportCitationsContent.tsx
+++ b/lib/components/oracle/reports/components/ReportCitationsContent.tsx
@@ -1,0 +1,119 @@
+import { CitationItem } from "@oracle";
+import { marked } from "marked";
+
+interface ReportCitationsContentProps {
+  citations: CitationItem[];
+}
+
+export function ReportCitationsContent({ citations }: ReportCitationsContentProps) {
+  if (!citations || citations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col space-y-4">
+      {/* Citations Header */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-600 p-3 sm:p-4">
+        <div className="flex items-center gap-2 mb-2 pb-2 border-b dark:border-gray-600">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5 text-blue-500 dark:text-blue-400 flex-shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+            <line x1="16" y1="13" x2="8" y2="13"></line>
+            <line x1="16" y1="17" x2="8" y2="17"></line>
+            <polyline points="10 9 9 9 8 9"></polyline>
+          </svg>
+          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            Report Citations
+          </h4>
+        </div>
+
+        {citations.map((item, index) => (
+          <div key={index} className="mb-4 relative group">
+            <div
+              className="prose dark:prose-invert prose-sm max-w-none py-1"
+              dangerouslySetInnerHTML={{
+                __html: marked.parse(item.text),
+              }}
+            />
+
+            {item.citations &&
+              Array.isArray(item.citations) &&
+              item.citations.length > 0 && (
+                <>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex flex-wrap items-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3 w-3 mr-1 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                      <polyline points="14 2 14 8 20 8"></polyline>
+                    </svg>
+                    <span className="italic mr-1">Source:</span>
+                    <span className="break-all">
+                      {item.citations[0].document_title}
+                    </span>
+                    {item.citations[0].start_page_number && (
+                      <span className="ml-1">
+                        (Pages{" "}
+                        {item.citations[0].start_page_number}-
+                        {item.citations[0].end_page_number})
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Citation hover/touch panel - adaptive for mobile */}
+                  <div className="absolute left-0 right-0 -bottom-1 opacity-0 invisible group-hover:opacity-100 group-hover:visible md:transition-all md:duration-200 transform translate-y-full z-10">
+                    <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 mt-2 shadow-lg">
+                      <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
+                        Cited Text:
+                      </h5>
+                      <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
+                        "{item.citations[0].cited_text}"
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Mobile-friendly citation toggle button */}
+                  <button 
+                    className="text-xs text-blue-600 dark:text-blue-400 mt-1 block md:hidden"
+                    onClick={(e) => {
+                      // Find the next sibling (the citation panel) and toggle its visibility
+                      const panel = e.currentTarget.parentElement?.querySelector('.mobile-citation-panel');
+                      if (panel) {
+                        panel.classList.toggle('hidden');
+                      }
+                    }}
+                  >
+                    View citation
+                  </button>
+
+                  {/* Mobile citation panel (initially hidden) */}
+                  <div className="mobile-citation-panel hidden mt-2 md:hidden">
+                    <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 shadow-sm">
+                      <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
+                        Cited Text:
+                      </h5>
+                      <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
+                        "{item.citations[0].cited_text}"
+                      </p>
+                    </div>
+                  </div>
+                </>
+              )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/components/oracle/reports/components/index.ts
+++ b/lib/components/oracle/reports/components/index.ts
@@ -6,3 +6,4 @@ export * from './AnalysisPanel';
 export * from './SqlAnalysisContent';
 export * from './WebSearchContent';
 export * from './PdfCitationsContent';
+export * from './ReportCitationsContent';

--- a/lib/components/oracle/utils/apiServices.ts
+++ b/lib/components/oracle/utils/apiServices.ts
@@ -477,7 +477,7 @@ export async function fetchAndParseReportData(
   projectName: string,
   token: string
 ): Promise<ReportData> {
-  const { mdx, analyses } = await getReportMDX(
+  const { mdx, analyses, report_with_citations } = await getReportMDX(
     apiEndpoint,
     reportId,
     projectName,
@@ -496,6 +496,7 @@ export async function fetchAndParseReportData(
     parsed,
     analyses: analyses,
     comments: fetchedComments,
+    report_with_citations: report_with_citations,
   };
 }
 

--- a/lib/components/oracle/utils/types.ts
+++ b/lib/components/oracle/utils/types.ts
@@ -39,10 +39,22 @@ export interface ListReportResponseItem {
 
 export type ListReportResponse = ListReportResponseItem[];
 
+export interface CitationItem {
+  text: string;
+  citations?: {
+    cited_text: string;
+    document_title: string;
+    end_page_number?: number;
+    start_page_number?: number;
+    type: string;
+  }[];
+}
+
 export interface ReportData {
   parsed: ReturnType<any> | null;
   analyses: OracleAnalysis[];
   comments: OracleReportComment[];
+  report_with_citations?: CitationItem[];
 }
 
 export interface ClarificationObject {


### PR DESCRIPTION
## Summary
- Added support for the new `report_with_citations` field returned by the `get_report_mdx` endpoint
- Created a new component to display report citations in a similar way to the PDF citations UI
- Report now checks if `report_with_citations` exists and has length > 0 to determine display mode

## Test plan
1. Create a new report that includes citations
2. Verify that citations are displayed properly with source information and hover functionality
3. Create a regular report without citations to verify it falls back to the standard display

🤖 Generated with [Claude Code](https://claude.ai/code)