### PR TITLE
Enhance report citations with interactive analysis links

### DIFF
--- a/lib/components/oracle/reports/OracleReport.tsx
+++ b/lib/components/oracle/reports/OracleReport.tsx
@@ -121,7 +121,10 @@ export function OracleReport({
           {reportWithCitations && reportWithCitations.length > 0 ? (
             <div className="max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0">
               <OracleNav onDelete={onDelete} />
-              <ReportCitationsContent citations={reportWithCitations} />
+              <ReportCitationsContent 
+                citations={reportWithCitations} 
+                setSelectedAnalysisIndex={setSelectedAnalysisIndex}
+              />
             </div>
           ) : (
             <EditorProvider

--- a/lib/components/oracle/reports/OracleThinkingCardPDF.tsx
+++ b/lib/components/oracle/reports/OracleThinkingCardPDF.tsx
@@ -9,16 +9,19 @@ export interface ThinkingStepPDF {
     [key: string]: any;
   };
   result: {
-    text: string;
-    type: string;
-    citations?: {
-      cited_text: string;
-      document_title: string;
-      end_page_number: number;
-      start_page_number: number;
+    analysis_id: string;
+    citations: {
+      text: string;
       type: string;
+      citations?: {
+        cited_text: string;
+        document_title: string;
+        end_page_number: number;
+        start_page_number: number;
+        type: string;
+      }[];
     }[];
-  }[];
+  };
 }
 
 export default function OracleThinkingCard({
@@ -27,7 +30,7 @@ export default function OracleThinkingCard({
   step: ThinkingStepPDF;
 }) {
   const { function_name, result, inputs } = step;
-  const text = result.map((item) => item.text).join("");
+  const text = result.citations.map((item) => item.text).join("");
 
   // Convert markdown to HTML and sanitize it
   const sanitizedHtml = sanitizeHtml(marked.parse(text), {

--- a/lib/components/oracle/reports/components/AnalysisContent.tsx
+++ b/lib/components/oracle/reports/components/AnalysisContent.tsx
@@ -10,35 +10,35 @@ interface AnalysisContentProps {
   setShowSqlQuery: (show: boolean) => void;
 }
 
-export function AnalysisContent({ 
-  analysis, 
-  viewMode, 
-  showSqlQuery, 
-  setShowSqlQuery 
+export function AnalysisContent({
+  analysis,
+  viewMode,
+  showSqlQuery,
+  setShowSqlQuery,
 }: AnalysisContentProps) {
   if (!analysis) return null;
 
   // SQL Analysis
-  if (analysis.analysis_id) {
+  if (analysis.sql) {
     return (
-      <SqlAnalysisContent 
-        analysis={analysis} 
-        viewMode={viewMode} 
-        showSqlQuery={showSqlQuery} 
+      <SqlAnalysisContent
+        analysis={analysis}
+        viewMode={viewMode}
+        showSqlQuery={showSqlQuery}
         setShowSqlQuery={setShowSqlQuery}
       />
     );
   }
-  
+
   // Web Search
   if (analysis.function_name === "web_search_tool") {
     return <WebSearchContent analysis={analysis} />;
   }
-  
+
   // PDF Citations
   if (analysis.function_name === "pdf_citations_tool") {
     return <PdfCitationsContent analysis={analysis} />;
   }
-  
+
   return null;
 }

--- a/lib/components/oracle/reports/components/AnalysisList.tsx
+++ b/lib/components/oracle/reports/components/AnalysisList.tsx
@@ -1,4 +1,5 @@
 import { OracleAnalysis } from "@oracle";
+import { useEffect, useRef } from "react";
 
 interface AnalysisListProps {
   analyses: OracleAnalysis[];
@@ -11,12 +12,44 @@ export function AnalysisList({
   selectedAnalysisIndex,
   onSelectAnalysis,
 }: AnalysisListProps) {
+  // Create refs for the container and the selected button
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll to the selected analysis when the selectedAnalysisIndex changes
+  useEffect(() => {
+    if (selectedButtonRef.current && containerRef.current) {
+      // Get the selected button and container
+      const button = selectedButtonRef.current;
+      const container = containerRef.current;
+      
+      // Scroll the button into view
+      // On mobile (horizontal scroll), scroll left
+      // On desktop (vertical scroll), scroll top
+      const isMobile = window.innerWidth < 768; // md breakpoint is 768px
+      
+      if (isMobile) {
+        // Horizontal scrolling for mobile
+        container.scrollLeft = button.offsetLeft - container.clientWidth / 2 + button.clientWidth / 2;
+      } else {
+        // Vertical scrolling for desktop
+        container.scrollTop = button.offsetTop - container.clientHeight / 2 + button.clientHeight / 2;
+      }
+    }
+  }, [selectedAnalysisIndex]);
+
   return (
-    <div className="w-full md:w-[250px] md:border-r dark:border-gray-700 overflow-x-auto md:overflow-x-visible md:overflow-y-auto bg-white dark:bg-gray-800">
+    <div 
+      ref={containerRef}
+      className="w-full md:w-[250px] md:border-r dark:border-gray-700 overflow-x-auto md:overflow-x-visible md:overflow-y-auto bg-white dark:bg-gray-800"
+    >
       <div className="flex md:flex-col min-w-max md:min-w-0">
         {analyses.map((analysis, index) => (
           <button
             key={index}
+            ref={selectedAnalysisIndex === index ? selectedButtonRef : null}
+            data-analysis-index={index}
+            data-analysis-id={analysis.analysis_id}
             onClick={() => onSelectAnalysis(index)}
             className={`flex-shrink-0 md:flex-shrink text-left p-3 md:w-full border-b dark:border-gray-700 text-sm ${
               index === 0 ? "" : "md:border-t-0"

--- a/lib/components/oracle/reports/components/AnalysisList.tsx
+++ b/lib/components/oracle/reports/components/AnalysisList.tsx
@@ -28,7 +28,7 @@ export function AnalysisList({
           >
             {/* Analysis type badge */}
             <div className="flex items-center mb-1.5">
-              {analysis.analysis_id && (
+              {analysis.sql && (
                 <span className="px-1.5 py-0.5 text-xs font-medium rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 mr-1.5">
                   SQL
                 </span>
@@ -44,7 +44,7 @@ export function AnalysisList({
                 </span>
               )}
             </div>
-            
+
             {/* Use max-height transition for smooth expansion */}
             <div
               className={`overflow-hidden transition-all duration-300 ${

--- a/lib/components/oracle/reports/components/AnalysisPanel.tsx
+++ b/lib/components/oracle/reports/components/AnalysisPanel.tsx
@@ -26,7 +26,7 @@ export function AnalysisPanel({
     analyses.length > 0 ? analyses[selectedAnalysisIndex] || null : null;
 
   return (
-    <div className="w-full lg:w-[600px] xl:w-[650px] 2xl:w-[800px] lg:sticky lg:top-4 self-start max-h-[calc(100vh-1rem)] flex flex-col border dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800 mt-4 lg:mt-0">
+    <div className="analysis-panel w-full lg:w-[600px] xl:w-[650px] 2xl:w-[800px] lg:sticky lg:top-4 self-start max-h-[calc(100vh-1rem)] flex flex-col border dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-gray-800 mt-4 lg:mt-0">
       {/* Header with view mode toggle */}
       <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 border-b dark:border-gray-700">
         <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200">

--- a/lib/components/oracle/reports/components/PdfCitationsContent.tsx
+++ b/lib/components/oracle/reports/components/PdfCitationsContent.tsx
@@ -58,86 +58,87 @@ export function PdfCitationsContent({ analysis }: PdfCitationsContentProps) {
           </h4>
         </div>
 
-        {Array.isArray(analysis.result) &&
-          analysis.result.map((item, index) => (
-            <div key={index} className="mb-4 relative group">
-              <div
-                className="prose dark:prose-invert prose-sm max-w-none py-1"
-                dangerouslySetInnerHTML={{
-                  __html: marked.parse(item.text),
-                }}
-              />
+        {analysis.result.citations.map((item, index) => (
+          <div key={index} className="mb-4 relative group">
+            <div
+              className="prose dark:prose-invert prose-sm max-w-none py-1"
+              dangerouslySetInnerHTML={{
+                __html: marked.parse(item.text),
+              }}
+            />
 
-              {item.citations &&
-                Array.isArray(item.citations) &&
-                item.citations.length > 0 && (
-                  <>
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex flex-wrap items-center">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-3 w-3 mr-1 flex-shrink-0 text-blue-500 dark:text-blue-400"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                        <polyline points="14 2 14 8 20 8"></polyline>
-                      </svg>
-                      <span className="italic mr-1">Source:</span>
-                      <span className="break-all">
-                        {item.citations[0].document_title}
-                      </span>
-                      {item.citations[0].start_page_number && (
-                        <span className="ml-1">
-                          (Pages{" "}
-                          {item.citations[0].start_page_number}-
-                          {item.citations[0].end_page_number})
-                        </span>
-                      )}
-                    </div>
-
-                    {/* Citation hover/touch panel - adaptive for mobile */}
-                    <div className="absolute left-0 right-0 -bottom-1 opacity-0 invisible group-hover:opacity-100 group-hover:visible md:transition-all md:duration-200 transform translate-y-full z-10">
-                      <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 mt-2 shadow-lg">
-                        <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
-                          Cited Text:
-                        </h5>
-                        <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
-                          "{item.citations[0].cited_text}"
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Mobile-friendly citation toggle button */}
-                    <button 
-                      className="text-xs text-blue-600 dark:text-blue-400 mt-1 block md:hidden"
-                      onClick={(e) => {
-                        // Find the next sibling (the citation panel) and toggle its visibility
-                        const panel = e.currentTarget.parentElement?.querySelector('.mobile-citation-panel');
-                        if (panel) {
-                          panel.classList.toggle('hidden');
-                        }
-                      }}
+            {item.citations &&
+              Array.isArray(item.citations) &&
+              item.citations.length > 0 && (
+                <>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex flex-wrap items-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3 w-3 mr-1 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
                     >
-                      View citation
-                    </button>
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                      <polyline points="14 2 14 8 20 8"></polyline>
+                    </svg>
+                    <span className="italic mr-1">Source:</span>
+                    <span className="break-all">
+                      {item.citations[0].document_title}
+                    </span>
+                    {item.citations[0].start_page_number && (
+                      <span className="ml-1">
+                        (Pages {item.citations[0].start_page_number}-
+                        {item.citations[0].end_page_number})
+                      </span>
+                    )}
+                  </div>
 
-                    {/* Mobile citation panel (initially hidden) */}
-                    <div className="mobile-citation-panel hidden mt-2 md:hidden">
-                      <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 shadow-sm">
-                        <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
-                          Cited Text:
-                        </h5>
-                        <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
-                          "{item.citations[0].cited_text}"
-                        </p>
-                      </div>
+                  {/* Citation hover/touch panel - adaptive for mobile */}
+                  <div className="absolute left-0 right-0 -bottom-1 opacity-0 invisible group-hover:opacity-100 group-hover:visible md:transition-all md:duration-200 transform translate-y-full z-10">
+                    <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 mt-2 shadow-lg">
+                      <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
+                        Cited Text:
+                      </h5>
+                      <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
+                        "{item.citations[0].cited_text}"
+                      </p>
                     </div>
-                  </>
-                )}
-            </div>
-          ))}
+                  </div>
+
+                  {/* Mobile-friendly citation toggle button */}
+                  <button
+                    className="text-xs text-blue-600 dark:text-blue-400 mt-1 block md:hidden"
+                    onClick={(e) => {
+                      // Find the next sibling (the citation panel) and toggle its visibility
+                      const panel =
+                        e.currentTarget.parentElement?.querySelector(
+                          ".mobile-citation-panel"
+                        );
+                      if (panel) {
+                        panel.classList.toggle("hidden");
+                      }
+                    }}
+                  >
+                    View citation
+                  </button>
+
+                  {/* Mobile citation panel (initially hidden) */}
+                  <div className="mobile-citation-panel hidden mt-2 md:hidden">
+                    <div className="bg-gray-50 dark:bg-gray-700 p-3 rounded-lg border dark:border-gray-600 shadow-sm">
+                      <h5 className="text-xs font-medium text-gray-700 dark:text-gray-200 mb-2">
+                        Cited Text:
+                      </h5>
+                      <p className="text-xs text-gray-600 dark:text-gray-300 italic bg-gray-100 dark:bg-gray-800 p-2 rounded">
+                        "{item.citations[0].cited_text}"
+                      </p>
+                    </div>
+                  </div>
+                </>
+              )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/lib/components/oracle/utils/types.ts
+++ b/lib/components/oracle/utils/types.ts
@@ -13,6 +13,7 @@ export interface OracleAnalysis {
   function_name: string;
   mdx?: string;
   question?: string;
+  sql?: string;
   inputs?: Record<string, any>;
   outputs?: Record<string, any>;
   rows?: Record<string, any>[];
@@ -20,7 +21,7 @@ export interface OracleAnalysis {
     title: string;
     dataIndex: string;
   }[];
-  result?: any;
+  result?: Record<string, any>;
   status?: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary
- Enable clicking on citations to select the corresponding analysis in the analysis panel
- Automatically scroll to the selected analysis for better user experience
- Improve citation UI to make it clearer that citations are interactive
- Remove citation text hover panel for a cleaner UI

## Test plan
1. Open a report with citations
2. Click on a citation and verify it selects the corresponding analysis in the right panel
3. Verify that the analysis panel automatically scrolls to show the selected analysis
4. Check that the UI clearly indicates citations are clickable

🤖 Generated with [Claude Code](https://claude.ai/code)