### PR TITLE
Improve report citations display

### DIFF
--- a/lib/components/oracle/reports/components/ReportCitationsContent.tsx
+++ b/lib/components/oracle/reports/components/ReportCitationsContent.tsx
@@ -116,19 +116,46 @@ export function ReportCitationsContent({
                     onClick={() => handleCitationClick(item.citations[0].document_title)}
                   >
                     <div className="flex items-center w-full">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                        <polyline points="14 2 14 8 20 8"></polyline>
-                      </svg>
+                      {item.citations[0].document_title.includes('text_to_sql') && (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M4 6h16M4 12h16m-7 6h7" />
+                        </svg>
+                      )}
+                      {item.citations[0].document_title.includes('pdf_citations') && (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                          <polyline points="14 2 14 8 20 8"></polyline>
+                        </svg>
+                      )}
+                      {item.citations[0].document_title.includes('web_search') && (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <circle cx="11" cy="11" r="8"></circle>
+                          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                        </svg>
+                      )}
                       <span className="break-all flex-grow">
-                        {item.citations[0].document_title}
+                        Dig Deeper
                       </span>
                       <svg 
                         xmlns="http://www.w3.org/2000/svg" 


### PR DESCRIPTION
## Summary
- Replace technical citation identifiers with user-friendly "Dig Deeper" text
- Add context-specific icons based on the citation type (SQL, PDF, or web search)

This leads to much nicer to read citations calls-to-actions
![image](https://github.com/user-attachments/assets/6e4493d4-ac2e-40cd-8c8a-ad727821aa3b)


## Test plan
- Test various report citations to ensure correct icons appear based on the citation type
- Verify the "Dig Deeper" text displays properly in all contexts
- Check that clicking still navigates to the appropriate analysis

🤖 Generated with [Claude Code](https://claude.ai/code)