### PR TITLE
Expand cited analysis content inline

### DIFF
--- a/lib/components/oracle/reports/OracleReport.tsx
+++ b/lib/components/oracle/reports/OracleReport.tsx
@@ -112,9 +112,9 @@ export function OracleReport({
       }}
     >
       <div className="relative overflow-auto">
-        <div className="relative oracle-report-ctr">
+        <div className="relative oracle-report-ctr w-full">
           {reportWithCitations && reportWithCitations.length > 0 ? (
-            <div className="max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0">
+            <div className="w-full max-w-none sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl mx-auto py-2 px-2 sm:px-4 md:px-6 mb-12 md:mb-0">
               <OracleNav onDelete={onDelete} />
               <ReportCitationsContent 
                 citations={reportWithCitations} 
@@ -130,7 +130,7 @@ export function OracleReport({
               editorProps={{
                 attributes: {
                   class:
-                    "max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl oracle-report-tiptap relative prose prose-base dark:prose-invert mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0 focus:outline-none *:cursor-default",
+                    "w-full max-w-none sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl oracle-report-tiptap relative prose prose-base dark:prose-invert mx-auto py-2 px-2 sm:px-4 md:px-6 mb-12 md:mb-0 focus:outline-none *:cursor-default",
                 },
               }}
             />

--- a/lib/components/oracle/reports/OracleReport.tsx
+++ b/lib/components/oracle/reports/OracleReport.tsx
@@ -11,7 +11,7 @@ import {
   ReportData,
   CitationItem
 } from "@oracle";
-import { LoadingState, ErrorState, AnalysisPanel, ReportCitationsContent } from "./components";
+import { LoadingState, ErrorState, ReportCitationsContent } from "./components";
 
 export function OracleReport({
   apiEndpoint,
@@ -35,11 +35,6 @@ export function OracleReport({
   const [reportWithCitations, setReportWithCitations] = useState<CitationItem[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
-
-  // State for analysis panel
-  const [selectedAnalysisIndex, setSelectedAnalysisIndex] = useState<number>(0);
-  const [viewMode, setViewMode] = useState<"table" | "chart">("table");
-  const [showSqlQuery, setShowSqlQuery] = useState<boolean>(false);
 
   useEffect(() => {
     // Skip if we're already loading or if we have data
@@ -116,14 +111,13 @@ export function OracleReport({
         }),
       }}
     >
-      <div className="flex flex-col lg:flex-row gap-4 relative overflow-auto">
-        <div className="flex-1 relative oracle-report-ctr">
+      <div className="relative overflow-auto">
+        <div className="relative oracle-report-ctr">
           {reportWithCitations && reportWithCitations.length > 0 ? (
             <div className="max-w-none sm:max-w-2xl lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl mx-auto py-2 px-4 sm:px-6 md:px-10 mb-12 md:mb-0">
               <OracleNav onDelete={onDelete} />
               <ReportCitationsContent 
                 citations={reportWithCitations} 
-                setSelectedAnalysisIndex={setSelectedAnalysisIndex}
               />
             </div>
           ) : (
@@ -142,19 +136,6 @@ export function OracleReport({
             />
           )}
         </div>
-
-        {/* Analysis panel */}
-        {validAnalyses.length > 0 && (
-          <AnalysisPanel
-            analyses={validAnalyses}
-            selectedAnalysisIndex={selectedAnalysisIndex}
-            setSelectedAnalysisIndex={setSelectedAnalysisIndex}
-            viewMode={viewMode}
-            setViewMode={setViewMode}
-            showSqlQuery={showSqlQuery}
-            setShowSqlQuery={setShowSqlQuery}
-          />
-        )}
       </div>
     </OracleReportContext.Provider>
   );

--- a/lib/components/oracle/reports/components/ReportCitationsContent.tsx
+++ b/lib/components/oracle/reports/components/ReportCitationsContent.tsx
@@ -158,116 +158,140 @@ export function ReportCitationsContent({
   };
 
   return (
-    <div className="flex flex-col space-y-4">
-      <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-600 p-3 sm:p-4">
-        {citations.map((item, index) => (
-          <div key={index} className="mb-4 relative group">
-            <div
-              className="prose dark:prose-invert prose-sm max-w-none py-1"
-              dangerouslySetInnerHTML={{
-                __html: marked.parse(item.text),
-              }}
-            />
+    <div className="flex flex-col space-y-4 mt-10">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-600 py-3 px-3 sm:px-5 lg:px-7">
+        {(() => {
+          // Track which citation sources have already been shown
+          const shownCitationSources = new Set<string>();
+          
+          return citations.map((item, index) => {
+            // Check if this citation has a valid document title
+            const hasValidCitation = item.citations && 
+              Array.isArray(item.citations) && 
+              item.citations.length > 0;
+            
+            // Get citation source ID
+            const citationSourceId = hasValidCitation ? 
+              item.citations[0].document_title.split(":").pop()?.trim() : null;
+            
+            // Check if we should show "Dig Deeper" for this citation
+            const shouldShowDigDeeper = citationSourceId && !shownCitationSources.has(citationSourceId);
+            
+            // If this is a new citation source, add it to our tracking set
+            if (shouldShowDigDeeper && citationSourceId) {
+              shownCitationSources.add(citationSourceId);
+            }
+            
+            return (
+              <div key={index} className="mb-4 relative group">
+                <div
+                  className="prose dark:prose-invert prose-sm max-w-none py-1"
+                  dangerouslySetInnerHTML={{
+                    __html: marked.parse(item.text),
+                  }}
+                />
 
-            {item.citations &&
-              Array.isArray(item.citations) &&
-              item.citations.length > 0 && (
-                <>
-                  <div
-                    className="text-xs border border-gray-200 dark:border-gray-600 rounded-md p-2 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 mt-1 flex flex-wrap items-center cursor-pointer hover:border-blue-400 dark:hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                    onClick={() =>
-                      handleCitationClick(
-                        index,
-                        item.citations[0].document_title
-                      )
-                    }
-                  >
-                    <div className="flex items-center w-full">
-                      {item.citations[0].document_title.includes(
-                        "text_to_sql"
-                      ) && (
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M4 6h16M4 12h16m-7 6h7" />
-                        </svg>
-                      )}
-                      {item.citations[0].document_title.includes(
-                        "pdf_citations"
-                      ) && (
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                          <polyline points="14 2 14 8 20 8"></polyline>
-                        </svg>
-                      )}
-                      {item.citations[0].document_title.includes(
-                        "web_search"
-                      ) && (
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <circle cx="11" cy="11" r="8"></circle>
-                          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-                        </svg>
-                      )}
-                      <span className="break-all flex-grow">Dig Deeper</span>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className={`h-3.5 w-3.5 ml-1 text-blue-500 dark:text-blue-400 transition-transform ${
-                          expandedCitations.has(index) ? "rotate-180" : ""
-                        }`}
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <polyline points="6 9 12 15 18 9"></polyline>
-                      </svg>
-                    </div>
-                    {item.citations[0].start_page_number && (
-                      <span className="text-gray-500 dark:text-gray-400 text-xs mt-1">
-                        Pages {item.citations[0].start_page_number}-
-                        {item.citations[0].end_page_number}
-                      </span>
-                    )}
-                  </div>
-
-                  {expandedCitations.has(index) && (
-                    <div className="mt-2 transition-all duration-200 ease-in-out max-h-[500px] overflow-y-auto">
-                      {getAnalysisContent(
-                        item.citations[0].document_title,
-                        analyses.findIndex(
-                          (analysis) =>
-                            analysis.analysis_id ===
+                {hasValidCitation && (
+                  <>
+                    {shouldShowDigDeeper && (
+                      <div
+                        className="text-xs border border-gray-200 dark:border-gray-600 rounded-md p-2 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 mt-1 flex flex-wrap items-center cursor-pointer hover:border-blue-400 dark:hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                        onClick={() =>
+                          handleCitationClick(
+                            index,
                             item.citations[0].document_title
-                              .split(":")
-                              .pop()
-                              ?.trim()
-                        )
-                      )}
-                    </div>
-                  )}
-                </>
-              )}
-          </div>
-        ))}
+                          )
+                        }
+                      >
+                        <div className="flex items-center w-full">
+                          {item.citations[0].document_title.includes(
+                            "text_to_sql"
+                          ) && (
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <path d="M4 6h16M4 12h16m-7 6h7" />
+                            </svg>
+                          )}
+                          {item.citations[0].document_title.includes(
+                            "pdf_citations"
+                          ) && (
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                              <polyline points="14 2 14 8 20 8"></polyline>
+                            </svg>
+                          )}
+                          {item.citations[0].document_title.includes(
+                            "web_search"
+                          ) && (
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <circle cx="11" cy="11" r="8"></circle>
+                              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                            </svg>
+                          )}
+                          <span className="break-all flex-grow">Dig Deeper</span>
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className={`h-3.5 w-3.5 ml-1 text-blue-500 dark:text-blue-400 transition-transform ${
+                              expandedCitations.has(index) ? "rotate-180" : ""
+                            }`}
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                          >
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                          </svg>
+                        </div>
+                        {item.citations[0].start_page_number && (
+                          <span className="text-gray-500 dark:text-gray-400 text-xs mt-1">
+                            Pages {item.citations[0].start_page_number}-
+                            {item.citations[0].end_page_number}
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {expandedCitations.has(index) && (
+                      <div className="mt-2 transition-all duration-200 ease-in-out max-h-[500px] overflow-y-auto">
+                        {getAnalysisContent(
+                          item.citations[0].document_title,
+                          analyses.findIndex(
+                            (analysis) =>
+                              analysis.analysis_id ===
+                              item.citations[0].document_title
+                                .split(":")
+                                .pop()
+                                ?.trim()
+                          )
+                        )}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            );
+          });
+        })()}
       </div>
     </div>
   );

--- a/lib/components/oracle/reports/components/ReportCitationsContent.tsx
+++ b/lib/components/oracle/reports/components/ReportCitationsContent.tsx
@@ -2,6 +2,9 @@ import { CitationItem } from "@oracle";
 import { marked } from "marked";
 import { useContext, useEffect, useState } from "react";
 import { OracleReportContext } from "../../utils/OracleReportContext";
+import { SqlAnalysisContent } from "./SqlAnalysisContent";
+import { WebSearchContent } from "./WebSearchContent";
+import { PdfCitationsContent } from "./PdfCitationsContent";
 
 interface ReportCitationsContentProps {
   citations: CitationItem[];
@@ -14,22 +17,38 @@ export function ReportCitationsContent({
 }: ReportCitationsContentProps) {
   const { analyses } = useContext(OracleReportContext);
   // Track which analysis indices have been found to enable highlighting
-  const [foundAnalysisIds, setFoundAnalysisIds] = useState<Set<string>>(new Set());
+  const [foundAnalysisIds, setFoundAnalysisIds] = useState<Set<string>>(
+    new Set()
+  );
+  // Track which citations are expanded
+  const [expandedCitations, setExpandedCitations] = useState<Set<number>>(
+    new Set()
+  );
+  // Track the view mode for SQL content
+  const [viewMode, setViewMode] = useState<"table" | "chart">("table");
+  // Track SQL query visibility - default to hidden
+  const [showSqlQuery, setShowSqlQuery] = useState<boolean>(false);
 
   // Find analysis IDs in document titles
   useEffect(() => {
     if (!citations || !analyses) return;
-    
+
     const foundIds = new Set<string>();
-    
-    citations.forEach(item => {
-      if (item.citations && Array.isArray(item.citations) && item.citations.length > 0) {
+
+    citations.forEach((item) => {
+      if (
+        item.citations &&
+        Array.isArray(item.citations) &&
+        item.citations.length > 0
+      ) {
         const documentTitle = item.citations[0].document_title;
         if (documentTitle) {
           const parts = documentTitle.split(":");
           if (parts.length >= 2) {
             const analysisId = parts[parts.length - 1].trim();
-            const exists = analyses.some(analysis => analysis.analysis_id === analysisId);
+            const exists = analyses.some(
+              (analysis) => analysis.analysis_id === analysisId
+            );
             if (exists) {
               foundIds.add(analysisId);
             }
@@ -37,7 +56,7 @@ export function ReportCitationsContent({
         }
       }
     });
-    
+
     setFoundAnalysisIds(foundIds);
   }, [citations, analyses]);
 
@@ -45,59 +64,102 @@ export function ReportCitationsContent({
     return null;
   }
 
-  // Function to handle citation click and select the related analysis
-  const handleCitationClick = (documentTitle: string) => {
+  // Function to handle citation click and expand/collapse the analysis content
+  const handleCitationClick = (index: number, documentTitle: string) => {
     // Parse the analysis_id from document_title format "some_text:analysis_id"
     const parts = documentTitle.split(":");
     if (parts.length < 2) return;
-    
+
     const analysisId = parts[parts.length - 1].trim();
-    
+
     // Find the index of the analysis in the analyses array
-    const analysisIndex = analyses.findIndex(analysis => analysis.analysis_id === analysisId);
-    
+    const analysisIndex = analyses.findIndex(
+      (analysis) => analysis.analysis_id === analysisId
+    );
+
     if (analysisIndex !== -1) {
-      // If setSelectedAnalysisIndex prop is provided, use it directly (preferred method)
-      if (setSelectedAnalysisIndex) {
-        setSelectedAnalysisIndex(analysisIndex);
-        return;
-      }
-      
-      // Fallback to DOM manipulation if the prop is not available
-      const analysisPanel = document.querySelector('.analysis-panel');
-      if (analysisPanel) {
-        const analysisButtons = analysisPanel.querySelectorAll('button[data-analysis-index]');
-        if (analysisButtons && analysisButtons.length > analysisIndex) {
-          (analysisButtons[analysisIndex] as HTMLButtonElement).click();
+      // Toggle the expanded state for this citation
+      setExpandedCitations((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(index)) {
+          newSet.delete(index);
+        } else {
+          newSet.add(index);
         }
-      }
+        return newSet;
+      });
     }
+  };
+
+  // Function to get the appropriate analysis component based on document type
+  const getAnalysisContent = (documentTitle: string, analysisIndex: number) => {
+    if (!analyses || analysisIndex === -1) return null;
+
+    const analysis = analyses[analysisIndex];
+
+    if (documentTitle.includes("text_to_sql")) {
+      return (
+        <div className="mt-2 border-l-2 border-blue-400 pl-3 py-2 bg-white dark:bg-gray-800 rounded">
+          <div className="flex items-center justify-start space-x-2 mb-3">
+            <button
+              onClick={() => setViewMode("table")}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                viewMode === "table"
+                  ? "bg-primary-highlight text-gray-200 dark:bg-blue-600 dark:text-white"
+                  : "bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              Table
+            </button>
+            <button
+              onClick={() => setViewMode("chart")}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                viewMode === "chart"
+                  ? "bg-primary-highlight text-gray-200 dark:bg-blue-600 dark:text-white"
+                  : "bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              Chart
+            </button>
+          </div>
+          <SqlAnalysisContent
+            analysis={analysis}
+            viewMode={viewMode}
+            showSqlQuery={showSqlQuery}
+            setShowSqlQuery={setShowSqlQuery}
+          />
+        </div>
+      );
+    }
+
+    if (documentTitle.includes("pdf_citations")) {
+      return (
+        <div className="mt-2 border-l-2 border-blue-400 pl-3 py-2 bg-white dark:bg-gray-800 rounded">
+          <PdfCitationsContent analysis={analysis} />
+        </div>
+      );
+    }
+
+    if (documentTitle.includes("web_search")) {
+      return (
+        <div className="mt-2 border-l-2 border-blue-400 pl-3 py-2 bg-white dark:bg-gray-800 rounded">
+          <WebSearchContent analysis={analysis} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="mt-2 border-l-2 border-blue-400 pl-3 py-2 text-sm bg-white dark:bg-gray-800 rounded">
+        <div className="font-medium mb-1 text-gray-700 dark:text-gray-200">
+          Analysis
+        </div>
+      </div>
+    );
   };
 
   return (
     <div className="flex flex-col space-y-4">
-      {/* Citations Header */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-600 p-3 sm:p-4">
-        <div className="flex items-center gap-2 mb-2 pb-2 border-b dark:border-gray-600">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-5 w-5 text-blue-500 dark:text-blue-400 flex-shrink-0"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-            <polyline points="14 2 14 8 20 8"></polyline>
-            <line x1="16" y1="13" x2="8" y2="13"></line>
-            <line x1="16" y1="17" x2="8" y2="17"></line>
-            <polyline points="10 9 9 9 8 9"></polyline>
-          </svg>
-          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-200">
-            Report Citations
-          </h4>
-        </div>
-
         {citations.map((item, index) => (
           <div key={index} className="mb-4 relative group">
             <div
@@ -111,12 +173,19 @@ export function ReportCitationsContent({
               Array.isArray(item.citations) &&
               item.citations.length > 0 && (
                 <>
-                  <div 
+                  <div
                     className="text-xs border border-gray-200 dark:border-gray-600 rounded-md p-2 bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 mt-1 flex flex-wrap items-center cursor-pointer hover:border-blue-400 dark:hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                    onClick={() => handleCitationClick(item.citations[0].document_title)}
+                    onClick={() =>
+                      handleCitationClick(
+                        index,
+                        item.citations[0].document_title
+                      )
+                    }
                   >
                     <div className="flex items-center w-full">
-                      {item.citations[0].document_title.includes('text_to_sql') && (
+                      {item.citations[0].document_title.includes(
+                        "text_to_sql"
+                      ) && (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
@@ -128,7 +197,9 @@ export function ReportCitationsContent({
                           <path d="M4 6h16M4 12h16m-7 6h7" />
                         </svg>
                       )}
-                      {item.citations[0].document_title.includes('pdf_citations') && (
+                      {item.citations[0].document_title.includes(
+                        "pdf_citations"
+                      ) && (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
@@ -141,7 +212,9 @@ export function ReportCitationsContent({
                           <polyline points="14 2 14 8 20 8"></polyline>
                         </svg>
                       )}
-                      {item.citations[0].document_title.includes('web_search') && (
+                      {item.citations[0].document_title.includes(
+                        "web_search"
+                      ) && (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           className="h-3.5 w-3.5 mr-1.5 flex-shrink-0 text-blue-500 dark:text-blue-400"
@@ -154,29 +227,43 @@ export function ReportCitationsContent({
                           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                         </svg>
                       )}
-                      <span className="break-all flex-grow">
-                        Dig Deeper
-                      </span>
-                      <svg 
-                        xmlns="http://www.w3.org/2000/svg" 
-                        className="h-3.5 w-3.5 ml-1 text-blue-500 dark:text-blue-400" 
-                        viewBox="0 0 24 24" 
-                        fill="none" 
-                        stroke="currentColor" 
+                      <span className="break-all flex-grow">Dig Deeper</span>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className={`h-3.5 w-3.5 ml-1 text-blue-500 dark:text-blue-400 transition-transform ${
+                          expandedCitations.has(index) ? "rotate-180" : ""
+                        }`}
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
                         strokeWidth="2"
                       >
-                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
-                        <polyline points="15 3 21 3 21 9"></polyline>
-                        <line x1="10" y1="14" x2="21" y2="3"></line>
+                        <polyline points="6 9 12 15 18 9"></polyline>
                       </svg>
                     </div>
                     {item.citations[0].start_page_number && (
                       <span className="text-gray-500 dark:text-gray-400 text-xs mt-1">
-                        Pages {item.citations[0].start_page_number}-{item.citations[0].end_page_number}
+                        Pages {item.citations[0].start_page_number}-
+                        {item.citations[0].end_page_number}
                       </span>
                     )}
                   </div>
 
+                  {expandedCitations.has(index) && (
+                    <div className="mt-2 transition-all duration-200 ease-in-out max-h-[500px] overflow-y-auto">
+                      {getAnalysisContent(
+                        item.citations[0].document_title,
+                        analyses.findIndex(
+                          (analysis) =>
+                            analysis.analysis_id ===
+                            item.citations[0].document_title
+                              .split(":")
+                              .pop()
+                              ?.trim()
+                        )
+                      )}
+                    </div>
+                  )}
                 </>
               )}
           </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Replace side panel citation view with inline expandable analysis content
- Show "Dig Deeper" button only once per analysis source
- Improve citation display with better spacing and expandable UI

![image](https://github.com/user-attachments/assets/4caa6228-6b6d-40d9-aad9-0633f319acfd)


## Test plan
- Verify cited content expands inline when "Dig Deeper" is clicked
- Check that SQL, PDF, and web search contents display correctly
- Ensure proper spacing between elements

🤖 Generated with [Claude Code](https://claude.ai/code)