### PR TITLE
Centralize UUID Generation with Fallback Support

### DIFF
--- a/lib/components/core-ui/Message.tsx
+++ b/lib/components/core-ui/Message.tsx
@@ -1,4 +1,5 @@
 import { CircleCheck, CircleAlert, Info, CircleX } from "lucide-react";
+import { generateUUID } from "../utils/utils";
 import React, { createContext, useContext, useSyncExternalStore } from "react";
 import { twMerge } from "tailwind-merge";
 
@@ -89,7 +90,7 @@ export function MessageManager(): MessageManager {
     persist?: boolean
   ) {
     const time = performance.now();
-    const id = crypto.randomUUID();
+    const id = generateUUID();
 
     list = [
       ...list,

--- a/lib/components/oracle/embed/OracleEmbed.tsx
+++ b/lib/components/oracle/embed/OracleEmbed.tsx
@@ -3,6 +3,7 @@ import {
   MessageManagerContext,
   MessageMonitor,
 } from "@ui-components";
+import { generateUUID } from "../../utils/utils";
 import { OracleHistorySidebar } from "./OracleHistorySidebar";
 import {
   useCallback,
@@ -55,7 +56,7 @@ export function OracleEmbed({
 }) {
   // Random UUID for upload new project option
   const { current: uploadNewProjectOption } = useRef<string>(
-    crypto.randomUUID().toString()
+    generateUUID()
   );
 
   // Refs and managers
@@ -163,7 +164,7 @@ export function OracleEmbed({
   // Handle new analysis creation
   const handleCreateNewAnalysis = useCallback(
     (question: string, projectName: string) => {
-      const analysisId = crypto.randomUUID() as string;
+      const analysisId = generateUUID() as string;
 
       // Either a new project was created or we are on the "new report" screen
       if (projectNames.indexOf(projectName) === -1 || !selectedItem) {

--- a/lib/components/oracle/embed/hooks/useAnalysisTree.ts
+++ b/lib/components/oracle/embed/hooks/useAnalysisTree.ts
@@ -8,7 +8,7 @@ import { raf } from "@utils/utils";
  * Hook for analysis tree management
  */
 export const useAnalysisTree = (
-  messageManager: MessageManager
+  messageManager: ReturnType<typeof MessageManager>
 ) => {
   // Function to handle analysis creation when in query-data mode
   const createNewFastAnalysis = useCallback(async function ({

--- a/lib/components/oracle/embed/hooks/useReportHandlers.ts
+++ b/lib/components/oracle/embed/hooks/useReportHandlers.ts
@@ -15,7 +15,7 @@ export const useReportHandlers = (
   updateUrlWithItemId: (itemId: string | number | null) => void,
   oracleHistory: OracleHistory,
   setOracleHistory: React.Dispatch<React.SetStateAction<OracleHistory>>,
-  messageManager: MessageManager
+  messageManager: ReturnType<typeof MessageManager>
 ) => {
   // Handle report deletion
   const onReportDelete = useCallback(async () => {

--- a/lib/components/oracle/reports/tiptap-extensions/comments/OracleCommentHandler.tsx
+++ b/lib/components/oracle/reports/tiptap-extensions/comments/OracleCommentHandler.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState, useSyncExternalStore } from "react";
+import { generateUUID } from "../../../../utils/utils";
 import { OracleCommentPopover } from "./OracleCommentPopover";
 import type { OracleReportComment } from "../../../utils";
 import {
@@ -233,7 +234,7 @@ function OracleCommentHandlerInner({
                     .chain()
                     .setNodeSelection(interactionState.pmPos.inside)
                     .addComment({
-                      id: crypto.randomUUID(),
+                      id: generateUUID(),
                       content: "",
                       user: localStorage.getItem("user"),
                     })

--- a/lib/components/query-data/analysis-tree-viewer/analysisTreeManager.ts
+++ b/lib/components/query-data/analysis-tree-viewer/analysisTreeManager.ts
@@ -2,6 +2,7 @@ import {
   AnalysisManager,
   AnalysisRowFromBackend,
 } from "../analysis/analysisManager.js";
+import { generateUUID } from "../../utils/utils";
 
 type TabTypes = "table" | "chart" | "pdf";
 
@@ -127,7 +128,7 @@ export interface AnalysisTreeManager {
  */
 export function AnalysisTreeManager(
   initialTree: AnalysisTree = {},
-  id: string | null = crypto.randomUUID()
+  id: string | null = generateUUID()
 ): AnalysisTreeManager {
   // Initializes the unique identifier for this analysis tree manager instance.
   let _id = id;

--- a/lib/components/query-data/analysis/analysis-results/AnalysisResults.tsx
+++ b/lib/components/query-data/analysis/analysis-results/AnalysisResults.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useMemo, useRef } from "react";
+import { generateUUID } from "../../../utils/utils";
 import { AnalysisOutputsTable } from "./AnalysisOutputTable";
 import { AnalysisError } from "./AnalysisError";
 import { AnalysisInputs } from "./AnalysisInputs";
@@ -145,7 +146,7 @@ export function AnalysisResults({
         // if we have an error message in the step, show that
         // if we have no parsedOutputs: show a message saying "No data found"
         content: (
-          <div key={crypto.randomUUID()}>
+          <div key={generateUUID()}>
             <AnalysisOutputsTable
               projectName={projectName}
               analysis={analysis}

--- a/lib/components/utils/utils.ts
+++ b/lib/components/utils/utils.ts
@@ -569,6 +569,18 @@ export const formatFileSize = (bytes: number): string => {
 
 /**
  * Generate a UUID v4 with fallback for environments where crypto.randomUUID is not available
+ * 
+ * This function can be imported directly from the package:
+ * ```
+ * import { generateUUID } from '@defogdotai/agents-ui-components/utils';
+ * 
+ * // Generate a full UUID
+ * const id = generateUUID();
+ * 
+ * // Generate a shortened UUID (e.g., 8 characters)
+ * const shortId = generateUUID(8);
+ * ```
+ * 
  * @param sliceLength Optional parameter to slice the UUID to a specific length (e.g. 8 characters)
  * @returns A UUID string
  */

--- a/lib/components/utils/utils.ts
+++ b/lib/components/utils/utils.ts
@@ -566,3 +566,24 @@ export const formatFileSize = (bytes: number): string => {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
 };
+
+/**
+ * Generate a UUID v4 with fallback for environments where crypto.randomUUID is not available
+ * @param sliceLength Optional parameter to slice the UUID to a specific length (e.g. 8 characters)
+ * @returns A UUID string
+ */
+export function generateUUID(sliceLength?: number): string {
+  try {
+    // Try to use the native crypto.randomUUID method
+    const uuid = crypto.randomUUID();
+    return sliceLength ? uuid.slice(0, sliceLength) : uuid;
+  } catch (error) {
+    // Fallback implementation for environments where crypto.randomUUID is not available
+    // This implementation follows the UUID v4 format
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    }).slice(0, sliceLength);
+  }
+}

--- a/lib/components/utils/websocket-manager.ts
+++ b/lib/components/utils/websocket-manager.ts
@@ -1,3 +1,5 @@
+import { generateUUID } from "./utils";
+
 interface WebSocketManagerOptions {
   /**
    * The url of the websocket.
@@ -139,7 +141,7 @@ export function createWebsocketManager(
   let _onClose = config.onClose;
   let _onError = config.onError;
   let _onTimeout = config.onTimeout;
-  const id = crypto.randomUUID().slice(0, 8);
+  const id = generateUUID(8);
 
   let eventListeners: any[] = [];
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Utility functions exported from the package
+ */
+export { generateUUID } from './components/utils/utils';
+// Add other utility exports here as needed

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/core-ui.d.ts",
       "import": "./dist/core-ui.js"
     },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js"
+    },
     "./css": "./dist/style.css"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default ({ mode }) => {
           agent: resolve(__dirname, "lib/agent.ts"),
           "core-ui": resolve(__dirname, "lib/core-ui.ts"),
           styles: resolve(__dirname, "lib/styles.ts"),
+          utils: resolve(__dirname, "lib/utils.ts"),
         },
         formats: ["es"],
       },


### PR DESCRIPTION
## Summary
- Centralizes UUID generation in a single `generateUUID()` utility function
- Adds fallback mechanism for environments where `crypto.randomUUID()` is not available
- Exports the utility function through package exports for easy consumption

## Usage Examples

```typescript
// Import the utility function directly
import { generateUUID } from '@defogdotai/agents-ui-components/utils';

// Generate a full UUID
const id = generateUUID();

// Generate a shortened UUID (e.g., 8 characters)
const shortId = generateUUID(8);
```

## Benefits
- Improves compatibility with environments that don't support `crypto.randomUUID()`
- Centralizes UUID generation logic in a single location for easier maintenance
- Adds optional parameter to get shortened UUIDs when needed
- Properly exports the function through package.json for external consumption

🤖 Generated with [Claude Code](https://claude.ai/code)