### PR TITLE
Add podcast export feature with global loading state

### DIFF
--- a/lib/components/oracle/reports/OracleReport.tsx
+++ b/lib/components/oracle/reports/OracleReport.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EditorProvider } from "@tiptap/react";
 import {
   extensions,
@@ -9,8 +9,13 @@ import {
   fetchAndParseReportData,
   OracleAnalysis,
   ReportData,
-  CitationItem
+  CitationItem,
+  exportAsMarkdown,
+  exportAsPdf,
+  exportAsPodcast
 } from "@oracle";
+import { Download, FileText, Mic } from "lucide-react";
+import { Button, Modal } from "@ui-components";
 import { LoadingState, ErrorState, ReportCitationsContent } from "./components";
 
 export function OracleReport({
@@ -35,6 +40,10 @@ export function OracleReport({
   const [reportWithCitations, setReportWithCitations] = useState<CitationItem[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isPodcastLoading, setIsPodcastLoading] = useState(false);
+  const exportDropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Skip if we're already loading or if we have data
@@ -73,6 +82,23 @@ export function OracleReport({
     }
   }, [reportId]);
 
+  // Add click outside handler to close dropdown
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        exportDropdownRef.current &&
+        !exportDropdownRef.current.contains(event.target as Node)
+      ) {
+        setExportDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
   if (loading) {
     return <LoadingState />;
   }
@@ -84,6 +110,105 @@ export function OracleReport({
   // Filter analyses to only include those without errors
   const validAnalyses = analyses.filter(
     (analysis) => !analysis?.error || analysis.error === ""
+  );
+
+  // Function to handle exporting as Markdown
+  const handleExportMarkdown = () => {
+    const fileName = `report-${reportId}.md`;
+    // For citation-based reports, we'll generate simple markdown
+    const markdownContent = reportWithCitations 
+      ? reportWithCitations.map(item => item.text || '').join('\n\n')
+      : mdx || '';
+    exportAsMarkdown(markdownContent, fileName);
+    setExportDropdownOpen(false);
+  };
+
+  // Function to handle exporting as PDF
+  const handleExportPdf = () => {
+    const fileName = `report-${reportId}.pdf`;
+    // For citation-based reports, we'll generate simple markdown
+    const markdownContent = reportWithCitations 
+      ? reportWithCitations.map(item => item.text || '').join('\n\n')
+      : mdx || '';
+    exportAsPdf(markdownContent, fileName);
+    setExportDropdownOpen(false);
+  };
+
+  // Function to handle exporting as Podcast
+  const handleExportPodcast = () => {
+    try {
+      // For citation-based reports, we'll generate simple markdown
+      const markdownContent = reportWithCitations 
+        ? reportWithCitations.map(item => item.text || '').join('\n\n')
+        : mdx || '';
+      setExportDropdownOpen(false);
+      exportAsPodcast(
+        markdownContent, 
+        reportId, 
+        apiEndpoint, 
+        projectName, 
+        token,
+        setIsPodcastLoading
+      ).catch(error => {
+        console.error(error);
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // This was moved up to maintain hooks order
+
+  const ExportDropdown = () => (
+    <div className="relative z-50" ref={exportDropdownRef}>
+      <Button
+        variant="secondary"
+        onClick={() => setExportDropdownOpen(!exportDropdownOpen)}
+        className={
+          exportDropdownOpen ? "bg-gray-100 dark:bg-gray-700" : ""
+        }
+      >
+        <Download className="w-5 h-5" />
+      </Button>
+
+      {exportDropdownOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg z-50 border dark:border-gray-700">
+          <div className="py-1">
+            <button
+              onClick={handleExportMarkdown}
+              className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"
+            >
+              <FileText className="w-4 h-4 mr-2" />
+              Export as Markdown
+            </button>
+            <button
+              onClick={handleExportPdf}
+              className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"
+            >
+              <FileText className="w-4 h-4 mr-2" />
+              Export as PDF
+            </button>
+            <button
+              onClick={handleExportPodcast}
+              disabled={isPodcastLoading}
+              className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"
+            >
+              {isPodcastLoading ? (
+                <>
+                  <div className="w-4 h-4 mr-2 border-t-2 border-blue-500 border-solid rounded-full animate-spin"></div>
+                  Generating podcast...
+                </>
+              ) : (
+                <>
+                  <Mic className="w-4 h-4 mr-2" />
+                  Export as Podcast
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 
   return (
@@ -109,13 +234,48 @@ export function OracleReport({
           token,
           initialComments: comments,
         }),
+        isLoading: isPodcastLoading,
+        setIsLoading: setIsPodcastLoading,
       }}
     >
       <div className="relative overflow-auto">
+        {isPodcastLoading && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="bg-white dark:bg-gray-800 rounded-lg p-5 flex flex-col items-center shadow-lg">
+              <div className="w-12 h-12 border-t-4 border-blue-500 border-solid rounded-full animate-spin mb-4"></div>
+              <p className="text-gray-800 dark:text-gray-200 font-medium">
+                Generating podcast transcript...
+              </p>
+              <p className="text-gray-600 dark:text-gray-400 text-sm mt-2">
+                This may take a minute, please wait.
+              </p>
+            </div>
+          </div>
+        )}
         <div className="relative oracle-report-ctr w-full">
           {reportWithCitations && reportWithCitations.length > 0 ? (
             <div className="w-full max-w-none sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl mx-auto py-2 px-2 sm:px-4 md:px-6 mb-12 md:mb-0">
-              <OracleNav onDelete={onDelete} />
+              <div className="sticky top-0 bg-white dark:bg-gray-800 z-10 flex items-center justify-between px-4 py-2 border-b dark:border-gray-700">
+                <Button variant="danger" onClick={() => setDeleteModalOpen(true)}>
+                  Delete
+                </Button>
+                
+                <ExportDropdown />
+
+                <Modal
+                  open={deleteModalOpen}
+                  onOk={() => {
+                    onDelete(reportId, projectName);
+                    setDeleteModalOpen(false);
+                  }}
+                  onCancel={() => setDeleteModalOpen(false)}
+                  okText="Yes, Delete"
+                  okVariant="danger"
+                  title="Delete Report"
+                >
+                  <p>Are you sure you want to delete this report? This action cannot be undone.</p>
+                </Modal>
+              </div>
               <ReportCitationsContent 
                 citations={reportWithCitations} 
               />

--- a/lib/components/oracle/utils/OracleReportContext.ts
+++ b/lib/components/oracle/utils/OracleReportContext.ts
@@ -81,7 +81,20 @@ export interface OracleReportContext {
 
   extra?: { [key: string]: any };
 
+  /**
+   * Comment manager for handling report comments
+   */
   commentManager?: CommentManager;
+  
+  /**
+   * Loading state indicator
+   */
+  isLoading?: boolean;
+  
+  /**
+   * Function to set loading state
+   */
+  setIsLoading?: (isLoading: boolean) => void;
 }
 
 /**
@@ -102,4 +115,6 @@ export const OracleReportContext = createContext<OracleReportContext>({
     introduction: "",
     recommendations: [],
   },
+  isLoading: false,
+  setIsLoading: () => {},
 });

--- a/lib/components/oracle/utils/exportUtils.ts
+++ b/lib/components/oracle/utils/exportUtils.ts
@@ -26,6 +26,58 @@ export const downloadFile = (
 };
 
 /**
+ * Converts MDX content to a podcast transcript format between two people
+ * 
+ * @param mdx - The MDX content to convert
+ * @param reportId - The ID of the report
+ * @param apiEndpoint - The API endpoint for podcast conversion
+ * @param projectName - The name of the project
+ * @param token - Authentication token
+ * @param onLoadingChange - Optional callback to update loading state
+ */
+export const exportAsPodcast = async (
+  mdx: string,
+  reportId: string,
+  apiEndpoint: string,
+  projectName: string,
+  token: string,
+  onLoadingChange?: (isLoading: boolean) => void
+): Promise<void> => {
+  try {
+    // Set loading state to true
+    onLoadingChange?.(true);
+    
+    // Create the request to the backend endpoint
+    const response = await fetch(`${apiEndpoint}/oracle/export_podcast`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        db_name: projectName,
+        report_id: parseInt(reportId),
+        token: token
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error exporting podcast: ${response.statusText}`);
+    }
+
+    const result = await response.json();
+    
+    // Download the transcript as a text file
+    downloadFile(result.transcript, `podcast-transcript-${reportId}.txt`, 'text/plain');
+  } catch (error) {
+    console.error('Error exporting podcast:', error);
+    throw error;
+  } finally {
+    // Set loading state to false regardless of success or failure
+    onLoadingChange?.(false);
+  }
+};
+
+/**
  * Exports the report content as a Markdown file
  *
  * @param mdx - The MDX content to export


### PR DESCRIPTION
## Summary
- Added a new podcast export feature that converts Oracle reports to podcast transcripts
- Implemented global loading state in OracleReportContext to show a loading overlay during export
- Added loading UI with spinner and clear messaging about the process
- This is a sister PR to an upcoming PR in the introspect repo that will implement the backend API endpoint

## Test plan
1. Open any Oracle report
2. Click the export button and select 'Export as Podcast'
3. Verify the loading overlay appears while processing
4. Verify the podcast transcript downloads as a text file when complete

🤖 Generated with [Claude Code](https://claude.ai/code)