### PR TITLE
Fix date parsing to avoid timezone issues

### DIFF
--- a/lib/components/observable-charts/plotUtils.ts
+++ b/lib/components/observable-charts/plotUtils.ts
@@ -2,7 +2,11 @@
 
 import * as Plot from "@observablehq/plot";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import * as d3Colors from "d3-scale-chromatic";
+
+// Extend dayjs with UTC plugin to handle dates without timezone consideration
+dayjs.extend(utc);
 
 export interface Dimensions {
   width: number;
@@ -374,14 +378,15 @@ function getXAxis(options: ChartOptions): Plot.Mark {
       if (options.xIsDate) {
         let dateXTick;
         try {
-          dateXTick = dayjs(d);
+          // Use UTC mode to ensure dates are parsed without timezone consideration
+          dateXTick = dayjs.utc(d);
         } catch (e) {
           dateXTick = d;
         }
 
-        // Calculate the total time range
-        const firstDate = dayjs(ticks[0]);
-        const lastDate = dayjs(ticks[ticks.length - 1]);
+        // Calculate the total time range using UTC mode
+        const firstDate = dayjs.utc(ticks[0]);
+        const lastDate = dayjs.utc(ticks[ticks.length - 1]);
         const totalDays = lastDate.diff(firstDate, "day");
 
         // Choose format based on time range
@@ -535,7 +540,7 @@ function transformInputData(data: any[], options: ChartOptions): DataRecord[] {
 function processDateFacets(data: AggregatedRecord[]): AggregatedRecord[] {
   return data.map((d) => ({
     ...d,
-    facet: dayjs(d.facet),
+    facet: dayjs.utc(d.facet),
   }));
 }
 

--- a/lib/components/observable-charts/utils/createChartUtils.ts
+++ b/lib/components/observable-charts/utils/createChartUtils.ts
@@ -1,5 +1,10 @@
 import { createChartManager, ChartManager } from "../ChartManagerContext";
 import { ParsedOutput } from "../../query-data/analysis/analysisManager";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+// Extend dayjs with UTC plugin to handle dates without timezone consideration
+dayjs.extend(utc);
 
 // Define Column interface since it's not exported from ChartManagerContext
 interface Column {
@@ -52,7 +57,14 @@ export function createChartData(
       description: "",
       colType: col.colType || inferColType(col),
       dataIndex: col.dataIndex || col.title || col.key,
-      dateToUnix: (date: string) => new Date(date).getTime() / 1000
+      dateToUnix: (date: string) => {
+        // Parse date in UTC to avoid timezone issues
+        const parts = date.match(/^(\d{4})-(\d{2})-(\d{2})/);
+        if (parts) {
+          return Date.UTC(+parts[1], +parts[2] - 1, +parts[3]) / 1000;
+        }
+        return new Date(date).getTime() / 1000;
+      }
     }));
 
     // Create a new chart manager with the formatted data

--- a/lib/components/observable-charts/utils/renderPlot.js
+++ b/lib/components/observable-charts/utils/renderPlot.js
@@ -6,6 +6,10 @@ import {
 } from "../plotUtils";
 import { convertWideToLong } from "@utils/utils";
 import dayjs from "dayjs";
+// Use ISO parsing to ignore timezone
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 export function renderPlot(container, dimensions, chartManager) {
   let generatedOptions = null;
@@ -23,8 +27,9 @@ export function renderPlot(container, dimensions, chartManager) {
   const xColumn = availableColumns.find((col) => col.key === selectedColumns.x);
 
   if (xColumn?.isDate) {
-    const minDate = dayjs.min(data.map((d) => dayjs(d[xColumn.key])));
-    const maxDate = dayjs.max(data.map((d) => dayjs(d[xColumn.key])));
+    // Parse dates without timezone by using UTC mode to avoid local timezone adjustments
+    const minDate = dayjs.min(data.map((d) => dayjs.utc(d[xColumn.key])));
+    const maxDate = dayjs.max(data.map((d) => dayjs.utc(d[xColumn.key])));
     const numDaysRange = (maxDate - minDate) / 1000 / 60 / 60 / 24;
 
     if (numDaysRange < 14) {
@@ -191,7 +196,8 @@ export function renderPlot(container, dimensions, chartManager) {
           tickRotate: -45,
           tickFormat: (d) => {
             if (xColumn?.isDate) {
-              const date = dayjs(d);
+              // Use UTC mode to ensure consistent date formatting without timezone consideration
+              const date = dayjs.utc(d);
               if (xColumn.rangeToShow === "year") {
                 return date.format("YYYY");
               } else if (xColumn.rangeToShow === "month") {


### PR DESCRIPTION
## Summary

Previously, dates in charts would be parsed in the local timezone. This was generally fine, but led to errors with bar charts that included years if the user was in any timezone east of GMT.

For example, in the example below - the correct value at the end is 2024. But it was previously displayed as 2025. This fixes it.

![image](https://github.com/user-attachments/assets/23492b78-1f78-4928-b517-df1f29807c04)


- Added dayjs UTC plugin to ensure dates are handled in a timezone-agnostic way
- Modified date parsing in all chart components to use UTC mode
- Enhanced date-to-unix conversion to better handle ISO dates