### PR TITLE
Add resizable history sidebar for Oracle reports

### DIFF
--- a/lib/components/core-ui/ResizableHandle.tsx
+++ b/lib/components/core-ui/ResizableHandle.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { GripVertical } from 'lucide-react';
 
 interface ResizableHandleProps {
   onResize: (newWidth: number) => void;
@@ -37,26 +38,45 @@ export const ResizableHandle: React.FC<ResizableHandleProps> = ({
     if (isDragging) {
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
+      // Add a class to the body to change cursor during dragging
+      document.body.classList.add('resize-sidebar');
     } else {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
+      document.body.classList.remove('resize-sidebar');
     }
     
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
+      document.body.classList.remove('resize-sidebar');
     };
   }, [isDragging, handleMouseMove, handleMouseUp]);
 
   return (
     <div
       className={twMerge(
-        'w-1 cursor-col-resize absolute right-0 top-0 h-full hover:bg-blue-300 dark:hover:bg-blue-700 z-30 active:bg-blue-400 dark:active:bg-blue-600 transition-colors',
-        isDragging ? 'bg-blue-400 dark:bg-blue-600' : 'bg-transparent',
+        'w-3 cursor-col-resize absolute right-0 top-0 h-full z-30 group flex items-center justify-center',
+        isDragging ? 'bg-blue-100 dark:bg-blue-900' : 'hover:bg-blue-50 dark:hover:bg-blue-900/50',
         className
       )}
       onMouseDown={handleMouseDown}
-    />
+      title="Drag to resize"
+    >
+      {/* Visible handle bar */}
+      <div className={twMerge(
+        'w-0.5 h-full mx-auto bg-gray-200 dark:bg-gray-700 group-hover:bg-blue-300 dark:group-hover:bg-blue-700',
+        isDragging ? 'bg-blue-400 dark:bg-blue-600' : ''
+      )} />
+      
+      {/* Center grip icon for better visibility */}
+      <div className={twMerge(
+        'absolute top-1/2 -translate-y-1/2 opacity-30 group-hover:opacity-100 transition-opacity',
+        isDragging ? 'opacity-100' : ''
+      )}>
+        <GripVertical size={16} className="text-gray-500 dark:text-gray-400 group-hover:text-blue-500 dark:group-hover:text-blue-400" />
+      </div>
+    </div>
   );
 };
 

--- a/lib/components/core-ui/ResizableHandle.tsx
+++ b/lib/components/core-ui/ResizableHandle.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback, useState, useEffect } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface ResizableHandleProps {
+  onResize: (newWidth: number) => void;
+  minWidth?: number;
+  maxWidth?: number;
+  className?: string;
+}
+
+export const ResizableHandle: React.FC<ResizableHandleProps> = ({
+  onResize,
+  minWidth = 200,
+  maxWidth = 500,
+  className = '',
+}) => {
+  const [isDragging, setIsDragging] = useState(false);
+  
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (!isDragging) return;
+    
+    // Calculate new width based on mouse position
+    const newWidth = Math.max(minWidth, Math.min(maxWidth, e.clientX));
+    onResize(newWidth);
+  }, [isDragging, minWidth, maxWidth, onResize]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    } else {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    }
+    
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  return (
+    <div
+      className={twMerge(
+        'w-1 cursor-col-resize absolute right-0 top-0 h-full hover:bg-blue-300 dark:hover:bg-blue-700 z-30 active:bg-blue-400 dark:active:bg-blue-600 transition-colors',
+        isDragging ? 'bg-blue-400 dark:bg-blue-600' : 'bg-transparent',
+        className
+      )}
+      onMouseDown={handleMouseDown}
+    />
+  );
+};
+
+export default ResizableHandle;

--- a/lib/components/core-ui/Sidebar.tsx
+++ b/lib/components/core-ui/Sidebar.tsx
@@ -1,7 +1,8 @@
 // sidebar that can be toggled open and closed
 import { LogOut } from "lucide-react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { twMerge } from "tailwind-merge";
+import { ResizableHandle } from "./ResizableHandle";
 
 interface SidebarProps {
   title?: React.ReactNode;
@@ -17,11 +18,18 @@ interface SidebarProps {
   beforeTitle?: React.ReactNode;
   disableClose?: boolean;
   onChange?: (isOpen: boolean) => void;
+  resizable?: boolean;
+  minWidth?: number;
+  maxWidth?: number;
+  defaultWidth?: number;
+  onWidthChange?: (width: number) => void;
 }
 
 /**
  * Sidebar component that can be toggled open and closed.
  */
+
+const LOCAL_STORAGE_WIDTH_KEY = 'oracle-sidebar-width';
 
 export function Sidebar({
   title = "Menu",
@@ -37,8 +45,22 @@ export function Sidebar({
   disableClose = false,
   beforeTitle = null,
   onChange = (...args) => {},
+  resizable = false,
+  minWidth = 200,
+  maxWidth = 500,
+  defaultWidth = 288, // w-72 default width
+  onWidthChange = () => {},
 }: SidebarProps) {
   const [sidebarOpen, setSidebarOpen] = useState(disableClose ? true : open);
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    if (resizable) {
+      // Try to get from localStorage
+      const savedWidth = localStorage.getItem(LOCAL_STORAGE_WIDTH_KEY);
+      return savedWidth ? parseInt(savedWidth) : defaultWidth;
+    }
+    return defaultWidth;
+  });
+  
   const contentRef = useRef(null);
   const contentContainerRef = useRef(null);
 
@@ -54,6 +76,14 @@ export function Sidebar({
     onChange(!sidebarOpen);
   };
 
+  const handleResize = useCallback((newWidth: number) => {
+    setSidebarWidth(newWidth);
+    onWidthChange(newWidth);
+    
+    // Save to localStorage
+    localStorage.setItem(LOCAL_STORAGE_WIDTH_KEY, newWidth.toString());
+  }, [onWidthChange]);
+
   useEffect(() => {
     setSidebarOpen(open);
   }, [open]);
@@ -62,11 +92,13 @@ export function Sidebar({
     if (!contentContainerRef.current || !contentRef.current) return;
 
     if (sidebarOpen) {
-      contentContainerRef.current.style.width = `${contentRef.current.clientWidth}px`;
+      contentContainerRef.current.style.width = resizable 
+        ? `${sidebarWidth}px` 
+        : `${contentRef.current.clientWidth}px`;
     } else {
       contentContainerRef.current.style.width = `0px`;
     }
-  }, [sidebarOpen]);
+  }, [sidebarOpen, sidebarWidth, resizable]);
 
   const defaultIconClasses = `toggle-button absolute top-1 rounded-tr-md rounded-br-md bg-inherit p-2 pl-1 self-start z-10 transition-all cursor-pointer text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 ${sidebarOpen ? "right-1" : "-right-7 border border-gray-200 dark:border-gray-700 border-l-0"}`;
 
@@ -81,13 +113,16 @@ export function Sidebar({
       <div
         ref={contentContainerRef}
         className="transition-all grow overflow-y-hidden"
+        style={resizable && sidebarOpen ? { width: `${sidebarWidth}px` } : {}}
       >
         <div
           className={twMerge(
-            "w-80 block text-gray-900 dark:text-gray-100",
+            "block text-gray-900 dark:text-gray-100",
+            resizable ? "" : "w-80",
             contentClassNames
           )}
           ref={contentRef}
+          style={resizable ? { width: '100%' } : {}}
         >
           {beforeTitle || <></>}
           {title ? (
@@ -100,6 +135,16 @@ export function Sidebar({
           {children}
         </div>
       </div>
+      
+      {/* Resizable handle */}
+      {resizable && sidebarOpen && (
+        <ResizableHandle 
+          onResize={handleResize} 
+          minWidth={minWidth}
+          maxWidth={maxWidth}
+        />
+      )}
+      
       {!disableClose && (
         <button
           className={twMerge(defaultIconClasses, iconClassNames)}

--- a/lib/components/oracle/embed/OracleHistorySidebar.tsx
+++ b/lib/components/oracle/embed/OracleHistorySidebar.tsx
@@ -43,7 +43,7 @@ export const OracleHistorySidebar: React.FC<OracleHistorySidebarProps> = React.m
           <span className="mr-2">📚</span> History
         </h2>
       }
-      contentClassNames="p-5 rounded-tl-lg relative sm:block min-h-96 max-h-full overflow-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent"
+      contentClassNames="p-5 pr-6 rounded-tl-lg relative sm:block min-h-96 max-h-full overflow-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent"
       resizable={true}
       minWidth={200}
       maxWidth={500}

--- a/lib/components/oracle/embed/OracleHistorySidebar.tsx
+++ b/lib/components/oracle/embed/OracleHistorySidebar.tsx
@@ -43,7 +43,11 @@ export const OracleHistorySidebar: React.FC<OracleHistorySidebarProps> = React.m
           <span className="mr-2">📚</span> History
         </h2>
       }
-      contentClassNames="w-72 p-5 rounded-tl-lg relative sm:block min-h-96 max-h-full overflow-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent"
+      contentClassNames="p-5 rounded-tl-lg relative sm:block min-h-96 max-h-full overflow-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent"
+      resizable={true}
+      minWidth={200}
+      maxWidth={500}
+      defaultWidth={288} // 288px = w-72 default width
     >
       <div className="space-y-4">
         {selectedProjectName !== uploadNewProjectOption ? (

--- a/lib/core-ui.ts
+++ b/lib/core-ui.ts
@@ -1,4 +1,5 @@
 export { Handle } from "./components/core-ui/Handle.tsx";
+export { ResizableHandle } from "./components/core-ui/ResizableHandle.tsx";
 
 export {
   useBreakPoint,
@@ -24,7 +25,7 @@ export { Modal } from "./components/core-ui/Modal.tsx";
 export { MultiSelect } from "./components/core-ui/MultiSelect.tsx";
 export { Popover } from "./components/core-ui/Popover.tsx";
 export { RangeSlider } from "./components/core-ui/RangeSlider.jsx";
-export { Sidebar } from "./components/core-ui/Sidebar.jsx";
+export { Sidebar } from "./components/core-ui/Sidebar.tsx";
 export { SingleSelect } from "./components/core-ui/SingleSelect.tsx";
 export { Slider } from "./components/core-ui/Slider.jsx";
 export { Table } from "./components/core-ui/Table.jsx";

--- a/lib/styles/index.scss
+++ b/lib/styles/index.scss
@@ -52,3 +52,13 @@
 }
 
 /* Dark mode styles already added in prose-dark.scss */
+
+/* Sidebar resize cursor */
+body.resize-sidebar {
+  cursor: col-resize !important;
+  
+  * {
+    cursor: col-resize !important;
+    user-select: none !important;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Implemented a draggable handle to resize the Oracle history sidebar
- Added visual indication with a grip handle and improved hover states
- Persists sidebar width in localStorage so it's preserved across sessions

![image](https://github.com/user-attachments/assets/91fe3f7b-0f86-4da0-9414-49d10f124e56)
