### PR TITLE
Add public sharing UI for Oracle reports

### DIFF
--- a/lib/components/oracle/reports/OraclePublicReport.tsx
+++ b/lib/components/oracle/reports/OraclePublicReport.tsx
@@ -36,8 +36,8 @@ export function OraclePublicReport({
         // Use the /api prefix for local development environment
         const isLocalDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
         const apiUrl = isLocalDev 
-          ? `/api/oracle/public/report/${publicUuid}`
-          : `${apiEndpoint}/oracle/public/report/${publicUuid}`;
+          ? `/api/public/report/${publicUuid}`
+          : `${apiEndpoint}/public/report/${publicUuid}`;
           
         console.log("Fetching from URL:", apiUrl);
         

--- a/lib/components/oracle/reports/OraclePublicReport.tsx
+++ b/lib/components/oracle/reports/OraclePublicReport.tsx
@@ -33,11 +33,8 @@ export function OraclePublicReport({
         
         console.log("Fetching public report with UUID:", publicUuid);
         
-        // Use the /api prefix for local development environment
-        const isLocalDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-        const apiUrl = isLocalDev 
-          ? `/api/public/report/${publicUuid}`
-          : `${apiEndpoint}/public/report/${publicUuid}`;
+        // Always use the correct endpoint path
+        const apiUrl = `${apiEndpoint}/public/report/${publicUuid}`;
           
         console.log("Fetching from URL:", apiUrl);
         

--- a/lib/components/oracle/reports/OraclePublicReport.tsx
+++ b/lib/components/oracle/reports/OraclePublicReport.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from "react";
+import { EditorProvider } from "@tiptap/react";
+import {
+  extensions,
+  CitationItem,
+  parseMDX,
+  OracleReportContext,
+  OracleAnalysis,
+} from "@oracle";
+import { ReportCitationsContent } from "./components";
+import { marked } from "marked";
+
+export function OraclePublicReport({
+  apiEndpoint,
+  publicUuid,
+}: {
+  apiEndpoint: string;
+  publicUuid: string;
+}) {
+  const [mdx, setMDX] = useState<string | null>(null);
+  const [reportWithCitations, setReportWithCitations] = useState<
+    CitationItem[] | null
+  >(null);
+  const [analyses, setAnalyses] = useState<OracleAnalysis[]>([]);
+  const [reportName, setReportName] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchPublicReport = async () => {
+      try {
+        setLoading(true);
+        
+        console.log("Fetching public report with UUID:", publicUuid);
+        
+        // Use the /api prefix for local development environment
+        const isLocalDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+        const apiUrl = isLocalDev 
+          ? `/api/oracle/public/report/${publicUuid}`
+          : `${apiEndpoint}/oracle/public/report/${publicUuid}`;
+          
+        console.log("Fetching from URL:", apiUrl);
+        
+        const response = await fetch(apiUrl, {
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          }
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error("Response error:", errorText);
+          throw new Error(`Failed to fetch report: ${response.status} ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        console.log("Report data received:", data);
+        const report = data.report;
+
+        if (!report) {
+          throw new Error("Invalid report format received");
+        }
+
+        if (report.mdx) {
+          setMDX(report.mdx);
+          const parsed = parseMDX(report.mdx);
+          // Handle any additional parsing if needed
+        }
+
+        if (report.report_content_with_citations) {
+          setReportWithCitations(report.report_content_with_citations);
+        }
+
+        if (report.analyses) {
+          console.log("Setting analyses:", report.analyses);
+          setAnalyses(report.analyses);
+        }
+
+        setReportName(report.report_name || "Report");
+      } catch (e: any) {
+        console.error("Error fetching report:", e);
+        setError(e.message || String(e));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (publicUuid) {
+      fetchPublicReport();
+    }
+  }, [apiEndpoint, publicUuid]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <div className="w-12 h-12 border-t-4 border-blue-500 border-solid rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen text-center p-4">
+        <div className="text-red-500 text-2xl mb-2">Error</div>
+        <div className="text-gray-700 dark:text-gray-300">{error}</div>
+      </div>
+    );
+  }
+
+  // Create a simplified report context object
+  const reportContextValue = {
+    apiEndpoint,
+    tables: {},
+    multiTables: {},
+    images: {},
+    analyses: analyses || [],
+    executiveSummary: {
+      title: reportName,
+      introduction: "",
+      recommendations: [],
+    },
+    reportId: "public",
+    projectName: "public",
+    token: "",
+    commentManager: {
+      subscribeToCommentUpdates: () => () => {},
+      getComments: () => [],
+      updateComments: () => {},
+    },
+    isLoading: false,
+    setIsLoading: () => {},
+  };
+
+  return (
+    <div className="relative overflow-auto bg-white dark:bg-gray-900 min-h-screen">
+      <div className="bg-white dark:bg-gray-900 shadow-sm mb-4 py-4 px-6">
+        <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">
+          {reportName}
+        </h1>
+        <div className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Public Report
+        </div>
+      </div>
+
+      <OracleReportContext.Provider value={reportContextValue}>
+        <div className="relative oracle-report-ctr w-full">
+          {reportWithCitations && reportWithCitations.length > 0 ? (
+            <div className="w-full max-w-none sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl mx-auto py-2 px-2 sm:px-4 md:px-6 mb-12 md:mb-0">
+              <ReportCitationsContent citations={reportWithCitations} />
+            </div>
+          ) : (
+            <EditorProvider
+              extensions={extensions}
+              content={mdx}
+              immediatelyRender={false}
+              editable={false}
+              editorProps={{
+                attributes: {
+                  class:
+                    "w-full max-w-none sm:max-w-3xl lg:max-w-4xl xl:max-w-5xl 2xl:max-w-6xl oracle-report-tiptap relative prose prose-base dark:prose-invert mx-auto py-2 px-2 sm:px-4 md:px-6 mb-12 md:mb-0 focus:outline-none *:cursor-default",
+                },
+              }}
+            />
+          )}
+        </div>
+      </OracleReportContext.Provider>
+    </div>
+  );
+}

--- a/lib/components/oracle/utils/apiServices.ts
+++ b/lib/components/oracle/utils/apiServices.ts
@@ -477,7 +477,7 @@ export async function fetchAndParseReportData(
   projectName: string,
   token: string
 ): Promise<ReportData> {
-  const { mdx, analyses, report_with_citations } = await getReportMDX(
+  const { mdx, analyses, report_with_citations, is_public, public_url } = await getReportMDX(
     apiEndpoint,
     reportId,
     projectName,
@@ -497,6 +497,8 @@ export async function fetchAndParseReportData(
     analyses: analyses,
     comments: fetchedComments,
     report_with_citations: report_with_citations,
+    is_public: is_public,
+    public_url: public_url,
   };
 }
 
@@ -563,6 +565,47 @@ export const deleteReport = async (
   } catch (error) {
     console.error("Error deleting report:", error);
     return false;
+  }
+};
+
+/**
+ * Toggle public status of a report
+ */
+export const toggleReportPublicStatus = async (
+  apiEndpoint: string,
+  reportId: string,
+  token: string,
+  projectName: string,
+  makePublic: boolean
+) => {
+  try {
+    const res = await fetch(
+      setupBaseUrl({
+        apiEndpoint,
+        protocol: "http",
+        path: "oracle/toggle_public_status",
+      }),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          db_name: projectName,
+          report_id: reportId,
+          token,
+          make_public: makePublic,
+        }),
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error("Failed to toggle public status");
+    }
+
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    console.error("Error toggling public status:", error);
+    throw error;
   }
 };
 

--- a/lib/components/oracle/utils/types.ts
+++ b/lib/components/oracle/utils/types.ts
@@ -36,6 +36,8 @@ export interface ListReportResponseItem {
   is_being_revised?: boolean;
   is_revision?: boolean;
   status?: string;
+  is_public?: boolean;
+  public_url?: string;
 }
 
 export type ListReportResponse = ListReportResponseItem[];
@@ -60,6 +62,8 @@ export interface ReportData {
   analyses: OracleAnalysis[];
   comments: OracleReportComment[];
   report_with_citations?: CitationItem[];
+  is_public?: boolean;
+  public_url?: string;
 }
 
 export interface ClarificationObject {

--- a/lib/oracle.ts
+++ b/lib/oracle.ts
@@ -2,6 +2,7 @@ export { CreateNewProject } from "./components/common/CreateNewProject";
 
 export { OracleEmbed } from "./components/oracle/embed/OracleEmbed";
 export { OracleReport } from "./components/oracle/reports/OracleReport";
+export { OraclePublicReport } from "./components/oracle/reports/OraclePublicReport";
 
 export { OracleNav } from "./components/oracle/reports/OracleNav";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defogdotai/agents-ui-components",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/test/oracle/public-report-viewer.html
+++ b/test/oracle/public-report-viewer.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Oracle Public Report Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./public-report-viewer.tsx"></script>
+  </body>
+</html>

--- a/test/oracle/public-report-viewer.tsx
+++ b/test/oracle/public-report-viewer.tsx
@@ -1,0 +1,105 @@
+import { OraclePublicReport } from "@oracle";
+import ReactDOM from "react-dom/client";
+import "../../lib/styles/index.scss";
+import { useState, useEffect } from "react";
+
+function PublicReportViewer() {
+  const [uuid, setUuid] = useState<string | null>(null);
+  const [darkMode, setDarkMode] = useState<boolean>(
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+  const [useSystemTheme, setUseSystemTheme] = useState<boolean>(true);
+
+  // Extract UUID from the URL path
+  useEffect(() => {
+    const path = window.location.pathname;
+    const uuidMatch = path.match(/\/oracle\/public\/report\/([^/]+)/);
+    
+    if (uuidMatch && uuidMatch[1]) {
+      setUuid(uuidMatch[1]);
+    } else {
+      // Fallback to URL parameters
+      const urlParams = new URLSearchParams(window.location.search);
+      const uuidParam = urlParams.get('uuid');
+      if (uuidParam) {
+        setUuid(uuidParam);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!useSystemTheme) return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (e: MediaQueryListEvent) => setDarkMode(e.matches);
+
+    // Set initial value
+    setDarkMode(mediaQuery.matches);
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [useSystemTheme]);
+
+  // Form submission handler
+  const handleUuidSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const newUuid = formData.get('uuid') as string;
+    if (newUuid) {
+      setUuid(newUuid);
+      // Update URL without reloading the page
+      const url = new URL(window.location.href);
+      url.searchParams.set('uuid', newUuid);
+      window.history.pushState({}, '', url);
+    }
+  };
+
+  return (
+    <div className={`min-h-screen ${darkMode ? "dark" : ""}`}>
+      <button
+        onClick={() => {
+          setUseSystemTheme(false);
+          setDarkMode(!darkMode);
+        }}
+        className="rounded-full fixed z-[100] top-2 right-2 p-2 bg-gray-600 dark:bg-gray-700 shadow-sm hover:shadow-md transition-all"
+      >
+        {darkMode ? "☀️" : "🌙"}
+      </button>
+
+      {!uuid ? (
+        <div className="flex flex-col items-center justify-center h-screen p-4">
+          <h1 className="text-2xl font-bold mb-4 text-gray-800 dark:text-gray-100">Oracle Public Report Viewer</h1>
+          <form onSubmit={handleUuidSubmit} className="flex flex-col gap-4 w-full max-w-md">
+            <div>
+              <label htmlFor="uuid" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Report UUID</label>
+              <input 
+                type="text" 
+                id="uuid" 
+                name="uuid" 
+                placeholder="Enter report UUID..." 
+                className="w-full p-2 border border-gray-300 dark:border-gray-700 rounded-md text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-800"
+                required
+              />
+            </div>
+            <button 
+              type="submit" 
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+            >
+              View Report
+            </button>
+          </form>
+        </div>
+      ) : (
+        <OraclePublicReport
+          // In development, the component will prepend /api to the URL
+          apiEndpoint={import.meta.env.VITE_API_ENDPOINT}
+          publicUuid={uuid}
+        />
+      )}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <PublicReportViewer />
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,38 +26,7 @@ export default ({ mode }) => {
     },
     server: {
       strictPort: false,
-      // Custom middleware to handle public report routes
       middlewareMode: false,
-      proxy: {
-        // For API calls to the backend
-        "/api/public/report": {
-          target: env.VITE_API_ENDPOINT,
-          changeOrigin: true,
-          rewrite: (path) => path.replace('/api', '')
-        }
-      },
-      // Make public report routes work
-      configureServer: (server) => {
-        server.middlewares.use((req, res, next) => {
-          // Check if the URL matches a public report path
-          if (req.url?.startsWith('/public/report/')) {
-            // Handle API requests vs. UI navigation
-            if (req.headers.accept?.includes('application/json')) {
-              // If this is a data request, proxy to the real API
-              req.url = '/api' + req.url;
-              next();
-            } else {
-              // If this is a page request, serve the public-report-viewer.html
-              const publicViewerPath = resolve(__dirname, 'test/oracle/public-report-viewer.html');
-              const html = fs.readFileSync(publicViewerPath, 'utf-8');
-              res.setHeader('Content-Type', 'text/html');
-              res.end(html);
-            }
-          } else {
-            next();
-          }
-        });
-      }
     },
     build: {
       lib: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default ({ mode }) => {
       middlewareMode: false,
       proxy: {
         // For API calls to the backend
-        "/api/oracle/public/report": {
+        "/api/public/report": {
           target: env.VITE_API_ENDPOINT,
           changeOrigin: true,
           rewrite: (path) => path.replace('/api', '')
@@ -40,7 +40,7 @@ export default ({ mode }) => {
       configureServer: (server) => {
         server.middlewares.use((req, res, next) => {
           // Check if the URL matches a public report path
-          if (req.url?.startsWith('/oracle/public/report/')) {
+          if (req.url?.startsWith('/public/report/')) {
             // Handle API requests vs. UI navigation
             if (req.headers.accept?.includes('application/json')) {
               // If this is a data request, proxy to the real API


### PR DESCRIPTION
## Summary
- Add UI components and functionality to enable public sharing of Oracle reports
- Create public report viewer component for displaying reports without authentication
- Implement toggle button and share dialog in the report view

## Test plan
- Test toggling reports between public and private
- Test copying and sharing public URLs
- Verify reports can be viewed without authentication via the public URL
- Test the public view in different environments (local dev, production)

🤖 Generated with [Claude Code](https://claude.ai/code)